### PR TITLE
Clear screen if too many partial updates happened

### DIFF
--- a/examples/terminal/main/config.h
+++ b/examples/terminal/main/config.h
@@ -2,6 +2,8 @@
 #include "firacode.h"
 #include "firacode_bold.h"
 
+static uint64_t MAX_UPDATES_SINCE_LAST_CLEAR = 10000;
+
 static unsigned int fallback_glyph = '?';
 static GFXfont* font = (GFXfont*)&FiraCode;
 static GFXfont* bold_font = (GFXfont*)&FiraCode_Bold;

--- a/examples/terminal/main/st.c
+++ b/examples/terminal/main/st.c
@@ -2783,7 +2783,7 @@ void render() {
       .x = 0,
       .y = offset,
       .width = EPD_WIDTH,
-      .height = height,
+      .height = height + 8,
     };
     epd_poweron();
     epd_draw_image(area, start_ptr, WHITE_ON_WHITE);
@@ -2801,7 +2801,7 @@ void render() {
       .x = 0,
       .y = offset,
       .width = EPD_WIDTH,
-      .height = height,
+      .height = height + 8,
     };
     epd_poweron();
     epd_draw_image(area, start_ptr, BLACK_ON_WHITE);


### PR DESCRIPTION
This PR adds a rough estimation how bad artifacts are obscuring the screen and clears/repaints it completely once a threshold is hit. Builds on #1. But could be easily separated if #1 is too hacky.