### PR TITLE
Terminal text contrast fades after 1 hour 11 minutes

### DIFF
--- a/examples/terminal/main/main.c
+++ b/examples/terminal/main/main.c
@@ -45,9 +45,9 @@ int max(int a, int b) {
   return a > b ? a : b;
 }
 
-void delay(uint32_t millis) { vTaskDelay(millis / portTICK_PERIOD_MS); }
+void delay(uint64_t millis) { vTaskDelay(millis / portTICK_PERIOD_MS); }
 
-uint32_t millis() { return esp_timer_get_time() / 1000; }
+uint64_t millis() { return esp_timer_get_time() / 1000; }
 
 int log_to_uart(const char* fmt, va_list args) {
     char buffer[256];

--- a/examples/terminal/main/st.c
+++ b/examples/terminal/main/st.c
@@ -2987,9 +2987,9 @@ static void render_line() {
 }
 
 static void draw_mask(Rect_t area, uint8_t* mask, bool* dirtyness) {
-    uint32_t start = esp_timer_get_time();
+    uint64_t start = esp_timer_get_time();
     epd_draw_frame_1bit_lines(area, mask, BLACK_ON_WHITE, 200, dirtyness);
-    uint32_t time_ms = (esp_timer_get_time() - start) / 1000;
+    uint64_t time_ms = (esp_timer_get_time() - start) / 1000;
     // The particles must be given ~20ms to follow the applied charge.
     if (time_ms < 20) {
       vTaskDelay(20 - time_ms);
@@ -3045,7 +3045,7 @@ void epd_render(void) {
     screen_tainted = 1;
 
     epd_poweron();
-    uint32_t t_poweron = esp_timer_get_time();
+    uint64_t t_poweron = esp_timer_get_time();
 
     bool boolean_line_dirtyness[EPD_HEIGHT];
     for (int i=0; i < EPD_HEIGHT; i++) {


### PR DESCRIPTION
Overflow caused by using int32_t instead of int64_t

vrolandAPP 6:02 PM
Nice catch, that's a classic overflow right here! esp_timer_get_time() returns an int64_t, but t_poweron is uint32_t. So, after 2^32/10^6/60 = 71.5 min = 1 hour 11 minutes t_poweron overflows and time_since_poweron_m will be > 10. Changing the time of t_poweron to int64_t should fix it :)