### PR TITLE
Fix bug when pressing up and down

### DIFF
--- a/examples/terminal/main/st.c
+++ b/examples/terminal/main/st.c
@@ -2694,8 +2694,8 @@ tresize(int col, int row)
 
 	/* allocate any new rows */
 	for (/* i = minrow */; i < row; i++) {
-		term.line[i] = xmalloc_32(col * sizeof(Glyph));
-		term.alt[i] = xmalloc_32(col * sizeof(Glyph));
+		term.line[i] = xmalloc(col * sizeof(Glyph));
+		term.alt[i] = xmalloc(col * sizeof(Glyph));
 	}
 	if (col > term.col) {
 		bp = term.tabs + term.col;


### PR DESCRIPTION
Bug found when scrolling using up and down in recent linux command history


vroland (@vroland:matrix.vroland.de)APP  2 hours ago
Hm, to me, that does not seem related to the change you did, it may just trigger the bug. Could you try to replace the calls to xmalloc_32 with xmalloc? (Or change xmalloc_32 to allocate external RAM) This could be unaligned memory access.
___
Core  0 register dump:
PC      : 0x400874da  PS      : 0x00060d30  A0      : 0x800d641b  A1      : 0x3ffdb050  
0x400874da: memmove at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/string/memmove.c:75

A2      : 0x40099e78  A3      : 0x40099e88  A4      : 0x00000440  A5      : 0x00000001  
A6      : 0x000000fe  A7      : 0x00000001  A8      : 0x00000000  A9      : 0x40099e88  
A10     : 0x00000001  A11     : 0x3ffb2da1  A12     : 0x3ffdb070  A13     : 0x0000000a  
A14     : 0xffffffff  A15     : 0x00000001  SAR     : 0x0000000e  EXCCAUSE: 0x00000003  
EXCVADDR: 0x40099e88  LBEG    : 0x4008754e  LEND    : 0x40087559  LCOUNT  : 0x00000000  
0x4008754e: memset at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/machine/xtensa/memset.S:150

0x40087559: memset at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/machine/xtensa/memset.S:160


Backtrace:0x400874d7:0x3ffdb050 0x400d6418:0x3ffdb070 0x400d6bbb:0x3ffdb0d0 0x400d6c16:0x3ffdb110 0x400d3bb3:0x3ffdb130
0x400874d7: memmove at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/string/memmove.c:66

0x400d6418: tdeletechar at /home/user/lilygo/epdiy/examples/terminal/build/../main/st.c:1367
 (inlined by) csihandle at /home/user/lilygo/epdiy/examples/terminal/build/../main/st.c:1870
 (inlined by) tputc at /home/user/lilygo/epdiy/examples/terminal/build/../main/st.c:2532

0x400d6bbb: twrite at /home/user/lilygo/epdiy/examples/terminal/build/../main/st.c:2614 (discriminator 2)

0x400d6c16: ttyread at /home/user/lilygo/epdiy/examples/terminal/build/../main/st.c:906

0x400d3bb3: read_task at /home/user/lilygo/epdiy/examples/terminal/build/../main/main.c:62 (discriminator 1)