### PR TITLE
add transparency support for images

### DIFF
--- a/src/epd_driver/epd_driver.c
+++ b/src/epd_driver/epd_driver.c
@@ -437,23 +437,34 @@ uint8_t epd_get_pixel(int x, int y, int fb_width, int fb_height, const uint8_t *
  return buf_val<<4;
 }
 
-void epd_draw_rotated_image(EpdRect image_area, const uint8_t *image_buffer, uint8_t *framebuffer) {
-  if (epd_get_rotation() != EPD_ROT_LANDSCAPE) {
+static void draw_rotated_transparent_image(EpdRect image_area, const uint8_t *image_buffer, uint8_t *framebuffer, uint8_t *transparent_color) {
     uint16_t x_offset = 0;
     uint16_t y_offset = 0;
+    uint8_t pixel_color;
     for (uint16_t y = 0; y < image_area.height; y++) {
         for (uint16_t x = 0; x < image_area.width; x++) {
           x_offset = image_area.x + x;
           y_offset = image_area.y + y;
           if (x_offset >= epd_rotated_display_width()) continue;
           if (y_offset >= epd_rotated_display_height()) continue;
-          epd_draw_pixel(
-            x_offset,
-            y_offset,
-            epd_get_pixel(x, y, image_area.width, image_area.height, image_buffer),
-            framebuffer);
+          pixel_color = epd_get_pixel(x, y, image_area.width, image_area.height, image_buffer);
+          if(transparent_color == NULL || pixel_color != (*transparent_color))
+              epd_draw_pixel(
+                x_offset,
+                y_offset,
+                pixel_color,
+                framebuffer);
         }
-      }
+    }
+}
+
+void epd_draw_rotated_transparent_image(EpdRect image_area, const uint8_t *image_buffer, uint8_t *framebuffer, uint8_t transparent_color) {
+    draw_rotated_transparent_image(image_area, image_buffer, framebuffer, &transparent_color);
+}
+
+void epd_draw_rotated_image(EpdRect image_area, const uint8_t *image_buffer, uint8_t *framebuffer) {
+  if (epd_get_rotation() != EPD_ROT_LANDSCAPE) {
+      draw_rotated_transparent_image(image_area, image_buffer, framebuffer, NULL);
     } else {
       epd_copy_to_framebuffer(image_area, image_buffer, framebuffer);
     }

--- a/src/epd_driver/include/epd_driver.h
+++ b/src/epd_driver/include/epd_driver.h
@@ -497,6 +497,12 @@ uint8_t epd_get_pixel(int x, int y, int fb_width, int fb_height, const uint8_t *
  */ 
 void epd_draw_rotated_image(EpdRect image_area, const uint8_t *image_buffer, uint8_t *framebuffer);
 
+/**
+ * Draw an image reading pixel per pixel and being rotation aware (via epd_draw_pixel)
+ * With an optional transparent color (color key transparency)
+ */
+void epd_draw_rotated_transparent_image(EpdRect image_area, const uint8_t *image_buffer, uint8_t *framebuffer, uint8_t transparent_color) ;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Finally tested, allowed me to fix one typo.
I get a bit confused in the API, it seems that there is some mix of "palette index" vs "0-255 range"...
Also in my sample code, using images generated by the python tool and very basic function call, I had to use "image_height-1" for the height of the surface, else it would draw very odd repetitions of the images on screen...