### PR TITLE
Add log error in red if PSRAM is not enabled with menuconfig

### DIFF
--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -26,6 +26,9 @@ EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
   assert(!already_initialized);
   assert(waveform != NULL);
 
+  #ifndef CONFIG_ESP32_SPIRAM_SUPPORT
+    ESP_LOGE("EPDiy", "Please enable PSRAM for the ESP32 (menuconfig→ Component config→ ESP32-specific)");
+  #endif
   EpdiyHighlevelState state;
   state.front_fb = heap_caps_malloc(fb_size, MALLOC_CAP_SPIRAM);
   assert(state.front_fb != NULL);

--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -27,7 +27,7 @@ EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
   assert(waveform != NULL);
 
   #ifndef CONFIG_ESP32_SPIRAM_SUPPORT
-    ESP_LOGE("EPDiy", "Please enable PSRAM for the ESP32 (menuconfig→ Component config→ ESP32-specific)");
+    ESP_LOGW("EPDiy", "Please enable PSRAM for the ESP32 (menuconfig→ Component config→ ESP32-specific)");
   #endif
   EpdiyHighlevelState state;
   state.front_fb = heap_caps_malloc(fb_size, MALLOC_CAP_SPIRAM);


### PR DESCRIPTION
Very easy 3 Liner to show a straightforward error when PSRAM is not enabled:

![Screenshot from Ubuntu](https://user-images.githubusercontent.com/2692928/127364670-774aba9b-efec-4aa7-83e1-38a110f78d3c.png)
