### PR TITLE
fix partial updates not working on rotated displays

### DIFF
--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -57,9 +57,9 @@ enum EpdDrawError epd_hl_update_screen(EpdiyHighlevelState* state, enum EpdDrawM
   return epd_hl_update_area(state, mode, temperature, epd_full_screen());
 }
 
-EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+static inline EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
   // If partial update uses full screen do not rotate anything
-  if (x != 0 && y != 0 && EPD_WIDTH != w && EPD_HEIGHT != h) {
+  if (!(x == 0 && y == 0 && epd_rotated_display_width() == w && epd_rotated_display_height() == h)) {
     // invert the current display rotation
     switch (epd_get_rotation())
     {

--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -57,6 +57,14 @@ enum EpdDrawError epd_hl_update_screen(EpdiyHighlevelState* state, enum EpdDrawM
   return epd_hl_update_area(state, mode, temperature, epd_full_screen());
 }
 
+static inline bool is_valid_area(EpdRect area)
+{
+    return area.x >= 0
+        && area.y >= 0
+        && area.width <= epd_rotated_display_width()
+        && area.height <= epd_rotated_display_height();
+}
+
 static inline EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
   // If partial update uses full screen do not rotate anything
   if (!(x == 0 && y == 0 && epd_rotated_display_width() == w && epd_rotated_display_height() == h)) {
@@ -97,6 +105,12 @@ static inline EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, 
 enum EpdDrawError epd_hl_update_area(EpdiyHighlevelState* state, enum EpdDrawMode mode, int temperature, EpdRect area) {
   assert(state != NULL);
   // Not right to rotate here since this copies part of buffer directly
+
+  if (!is_valid_area(area)) {
+      ESP_LOGE("epdiy", "Invalid area given to epd_hl_update_area: (x=%d, y=%d, width=%d, height=%d)",
+          area.x, area.y, area.width, area.height);
+      return EPD_DRAW_INVALID_CROP;
+  }
 
   bool previously_white = false;
   bool previously_black = false;

--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -65,9 +65,9 @@ static inline bool is_valid_area(EpdRect area)
         && area.height <= EPD_HEIGHT;
 }
 
-static inline EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+static inline EpdRect _inverse_rotated_area(EpdRect area) {
   // If partial update uses full screen do not rotate anything
-  if (!(x == 0 && y == 0 && EPD_WIDTH == w && EPD_HEIGHT == h)) {
+  if (!(area.x == 0 && area.y == 0 && EPD_WIDTH == area.width && EPD_HEIGHT == area.height)) {
     // invert the current display rotation
     switch (epd_get_rotation())
     {
@@ -76,30 +76,27 @@ static inline EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, 
         break;
       // 1 90 ° clockwise
       case EPD_ROT_PORTRAIT:
-        _swap_int(x, y);
-        _swap_int(w, h);
-        x = EPD_WIDTH - x - w;
+        _swap_int(area.x, area.y);
+        _swap_int(area.width, area.height);
+        area.x = EPD_WIDTH - area.x - area.width;
         break;
 
       case EPD_ROT_INVERTED_LANDSCAPE:
         // 3 180°
-        x = EPD_WIDTH - x - w;
-        y = EPD_HEIGHT - y - h;
+        area.x = EPD_WIDTH - area.x - area.width;
+        area.y = EPD_HEIGHT - area.y - area.height;
         break;
 
       case EPD_ROT_INVERTED_PORTRAIT:
         // 3 270 °
-        _swap_int(x, y);
-        _swap_int(w, h);
-        y = EPD_HEIGHT - y - h;
+        _swap_int(area.x, area.y);
+        _swap_int(area.width, area.height);
+        area.y = EPD_HEIGHT - area.y - area.height;
         break;
     }
   }
 
-  EpdRect rotated =  {
-    x, y, w, h
-  };
-  return rotated;
+  return area;
 }
 
 enum EpdDrawError epd_hl_update_area(EpdiyHighlevelState* state, enum EpdDrawMode mode, int temperature, EpdRect area) {
@@ -115,11 +112,7 @@ enum EpdDrawError epd_hl_update_area(EpdiyHighlevelState* state, enum EpdDrawMod
   bool previously_white = false;
   bool previously_black = false;
   // Check rotation FIX
-  EpdRect rotated_area = _inverse_rotated_area(area.x, area.y, area.width, area.height);
-  area.x = rotated_area.x;
-  area.y = rotated_area.y;
-  area.width = rotated_area.width;
-  area.height = rotated_area.height;
+  area = _inverse_rotated_area(area);
 
   //FIXME: use crop information here, if available
   EpdRect diff_area = epd_difference_image_cropped(

--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -61,13 +61,13 @@ static inline bool is_valid_area(EpdRect area)
 {
     return area.x >= 0
         && area.y >= 0
-        && area.width <= epd_rotated_display_width()
-        && area.height <= epd_rotated_display_height();
+        && area.width <= EPD_WIDTH
+        && area.height <= EPD_HEIGHT;
 }
 
 static inline EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
   // If partial update uses full screen do not rotate anything
-  if (!(x == 0 && y == 0 && epd_rotated_display_width() == w && epd_rotated_display_height() == h)) {
+  if (!(x == 0 && y == 0 && EPD_WIDTH == w && EPD_HEIGHT == h)) {
     // invert the current display rotation
     switch (epd_get_rotation())
     {


### PR DESCRIPTION
When I'm performing a partial update on a rotated (e.g. portrait mode) display, and either one of `x` or `y` of the bounding box is `0`, nothing is updated at all.

I think I located the issue inside the `_rotated_area` function. At least after applying these changes, my code started to work.

Reading the comment above, it looks like to me, the condition was wrong. That function _should_ only rotate if the given bounding box is **not** the full screen. A bounding box is only full screen, if `x == 0 && y == 0 && width == EPD_WIDTH && height == EPD_HEIGHT`. The condition would therefore need to invert this, either by wrapping with `!(is_full_screen)`, which I find much more readable, or by inverting every part to: `x !=0 || y != 0 || width != EPD_WIDTH || height != EPD_HEIGHT`.

What I'm not sure about, are the `width` and `height` checks, because someone might use `epd_rotated_display_width()` (and `..._height()`), which returns a different value than `EPD_WIDTH` depending on the current rotation, doesn't it?

Code to reproduce: https://codeberg.org/jdoubleu/epd_display_test#partial-update-at-0-0

Thanks to @tiri for his help finding this bug!