### PR TITLE
Prevent conflict with buttons on LilyGOT54.7 boards

### DIFF
--- a/src/epd_driver/epd_temperature.c
+++ b/src/epd_driver/epd_temperature.c
@@ -3,6 +3,12 @@
 #include "esp_log.h"
 #include "display_ops.h"
 
+#ifdef CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
+void epd_temperature_init() {}
+float epd_ambient_temperature() {
+  return 21.0;
+}
+#else
 #ifndef CONFIG_EPD_BOARD_REVISION_V6
 /// Use GPIO 35 for boards v4 - v5
 static const adc1_channel_t channel = ADC1_CHANNEL_7;
@@ -41,9 +47,8 @@ float epd_ambient_temperature() {
 void epd_temperature_init() {}
 
 float epd_ambient_temperature() {
-    return tps_read_thermistor(EPDIY_I2C_PORT);
+  return tps_read_thermistor(EPDIY_I2C_PORT);
 }
 
-
-
+#endif
 #endif

--- a/src/epd_driver/epd_temperature.c
+++ b/src/epd_driver/epd_temperature.c
@@ -5,7 +5,9 @@
 
 #ifdef CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
 void epd_temperature_init() {}
-float epd_ambient_temperature() {
+float epd_ambient_temperature()
+{
+  ESP_LOGW("epd_temperature", "No ambient temperature sensor - returning 21C");
   return 21.0;
 }
 #else
@@ -16,23 +18,31 @@ static esp_adc_cal_characteristics_t adc_chars;
 
 #define NUMBER_OF_SAMPLES 100
 
-void epd_temperature_init() {
+void epd_temperature_init()
+{
   esp_adc_cal_value_t val_type = esp_adc_cal_characterize(
       ADC_UNIT_1, ADC_ATTEN_DB_6, ADC_WIDTH_BIT_12, 1100, &adc_chars);
-  if (val_type == ESP_ADC_CAL_VAL_EFUSE_TP) {
+  if (val_type == ESP_ADC_CAL_VAL_EFUSE_TP)
+  {
     ESP_LOGI("epd_temperature", "Characterized using Two Point Value\n");
-  } else if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
+  }
+  else if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF)
+  {
     ESP_LOGI("esp_temperature", "Characterized using eFuse Vref\n");
-  } else {
+  }
+  else
+  {
     ESP_LOGI("esp_temperature", "Characterized using Default Vref\n");
   }
   adc1_config_width(ADC_WIDTH_BIT_12);
   adc1_config_channel_atten(channel, ADC_ATTEN_DB_6);
 }
 
-float epd_ambient_temperature() {
+float epd_ambient_temperature()
+{
   uint32_t value = 0;
-  for (int i = 0; i < NUMBER_OF_SAMPLES; i++) {
+  for (int i = 0; i < NUMBER_OF_SAMPLES; i++)
+  {
     value += adc1_get_raw(channel);
   }
   value /= NUMBER_OF_SAMPLES;
@@ -46,7 +56,8 @@ float epd_ambient_temperature() {
 
 void epd_temperature_init() {}
 
-float epd_ambient_temperature() {
+float epd_ambient_temperature()
+{
   return tps_read_thermistor(EPDIY_I2C_PORT);
 }
 

--- a/src/epd_driver/font.c
+++ b/src/epd_driver/font.c
@@ -43,7 +43,7 @@ static inline int max(int x, int y) { return x > y ? x : y; }
 
 static int utf8_len(const uint8_t ch) {
   int len = 0;
-  for (utf_t **u = utf; *u; ++u) {
+  for (utf_t **u = utf; (*u)->mask; ++u) {
     if ((ch & ~(*u)->mask) == (*u)->lead) {
       break;
     }


### PR DESCRIPTION
Fixes: #112 

On the LilyGoT5 4.7 boards GPIO35 is connected to a button with a pullup resistor so can't be used for reading temperature values.

I've added a `#define` to provide dummy functions.