### PR TITLE
Add pragma once to epd_highlevel.h

### DIFF
--- a/src/epd_driver/include/epd_highlevel.h
+++ b/src/epd_driver/include/epd_highlevel.h
@@ -62,7 +62,7 @@
 extern "C" {
 
 #endif
-
+#pragma once
 #include "epd_driver.h"
 #include <stdint.h>
 


### PR DESCRIPTION
To avoid errors when files is included from several headers in a project.