### PR TITLE
Change advance_y type in epd_internals.h

### DIFF
--- a/src/epd_driver/include/epd_internals.h
+++ b/src/epd_driver/include/epd_internals.h
@@ -136,7 +136,7 @@ typedef struct {
   const EpdUnicodeInterval *intervals; ///< Valid unicode intervals for this font
   uint32_t interval_count;    ///< Number of unicode intervals.
   bool compressed;            ///< Does this font use compressed glyph bitmaps?
-  uint8_t advance_y;          ///< Newline distance (y axis)
+  uint16_t advance_y;         ///< Newline distance (y axis)
   int ascender;               ///< Maximal height of a glyph above the base line
   int descender;              ///< Maximal height of a glyph below the base line
 } EpdFont;


### PR DESCRIPTION
Pretty simple modification that solves #94.

As suggested I've also checked `font.c` but it should be fine as it is since `cursor_y` is defined as `int`. 
The code has been tested on a LilyGo TTGO T5 4.7inch e-ink display.