### PR TITLE
Added i2s gpio attach/detach on epd_poweron/off

### DIFF
--- a/src/epd_driver/display_ops.c
+++ b/src/epd_driver/display_ops.c
@@ -95,28 +95,25 @@ void epd_base_init(uint32_t epd_row_width) {
   push_cfg(&config_reg);
 
   // Setup I2S
-  i2s_bus_config i2s_config;
   // add an offset off dummy bytes to allow for enough timing headroom
-  i2s_config.epd_row_width = epd_row_width + 32;
-  i2s_config.clock = CKH;
-  i2s_config.start_pulse = STH;
-  i2s_config.data_0 = D0;
-  i2s_config.data_1 = D1;
-  i2s_config.data_2 = D2;
-  i2s_config.data_3 = D3;
-  i2s_config.data_4 = D4;
-  i2s_config.data_5 = D5;
-  i2s_config.data_6 = D6;
-  i2s_config.data_7 = D7;
-
-  i2s_bus_init(&i2s_config);
+  i2s_bus_init( epd_row_width + 32 );
 
   rmt_pulse_init(CKV);
 }
 
-void epd_poweron() { cfg_poweron(&config_reg);  }
+void epd_poweron() { 
+  #if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
+  i2s_gpio_attach();
+  #endif
+  cfg_poweron(&config_reg);
+}
 
-void epd_poweroff() { cfg_poweroff(&config_reg); }
+void epd_poweroff() {
+  cfg_poweroff(&config_reg);
+  #if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
+  i2s_gpio_detach();
+  #endif
+}
 
 void epd_base_deinit(){
   epd_poweroff();

--- a/src/epd_driver/display_ops.c
+++ b/src/epd_driver/display_ops.c
@@ -101,18 +101,14 @@ void epd_base_init(uint32_t epd_row_width) {
   rmt_pulse_init(CKV);
 }
 
-void epd_poweron() { 
-  #if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
+void epd_poweron() {
   i2s_gpio_attach();
-  #endif
   cfg_poweron(&config_reg);
 }
 
 void epd_poweroff() {
   cfg_poweroff(&config_reg);
-  #if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
   i2s_gpio_detach();
-  #endif
 }
 
 void epd_base_deinit(){

--- a/src/epd_driver/i2s_data_bus.h
+++ b/src/epd_driver/i2s_data_bus.h
@@ -12,32 +12,42 @@
 /**
  * I2S bus configuration parameters.
  */
-typedef struct {
-  /// GPIO numbers of the parallel bus pins.
-  gpio_num_t data_0;
-  gpio_num_t data_1;
-  gpio_num_t data_2;
-  gpio_num_t data_3;
-  gpio_num_t data_4;
-  gpio_num_t data_5;
-  gpio_num_t data_6;
-  gpio_num_t data_7;
+// typedef struct {
+//   /// GPIO numbers of the parallel bus pins.
+//   gpio_num_t data_0;
+//   gpio_num_t data_1;
+//   gpio_num_t data_2;
+//   gpio_num_t data_3;
+//   gpio_num_t data_4;
+//   gpio_num_t data_5;
+//   gpio_num_t data_6;
+//   gpio_num_t data_7;
 
-  /// Data clock pin.
-  gpio_num_t clock;
+//   /// Data clock pin.
+//   gpio_num_t clock;
 
-  /// "Start Pulse", enabling data input on the slave device (active low)
-  gpio_num_t start_pulse;
+//   /// "Start Pulse", enabling data input on the slave device (active low)
+//   gpio_num_t start_pulse;
 
-  // Width of a display row in pixels.
-  uint32_t epd_row_width;
-} i2s_bus_config;
+//   // Width of a display row in pixels.
+//   uint32_t epd_row_width;
+// } i2s_bus_config;
 
 /**
  * Initialize the I2S data bus for communication
  * with a 8bit parallel display interface.
  */
-void i2s_bus_init(i2s_bus_config *cfg);
+void i2s_bus_init(uint32_t epd_row_width);
+
+/**
+ * Attach I2S to gpio's
+ */
+void i2s_gpio_attach();
+
+/**
+ * Detach I2S from gpio's
+ */
+void i2s_gpio_detach();
 
 /**
  * Get the currently writable line buffer.


### PR DESCRIPTION
bug fix for current leaking issue: https://github.com/vroland/epdiy/issues/136#issuecomment-1035410191

I do some changes in i2s_data_bus* :
- removed use of "i2s_bus_config i2s_config" as only variable it carry is epd_row_width, rest are globals anyway,
- added i2s_gpio_attach/detach

In display_ops.c added calls to i2s_gpio_attach/detach on epd_poweron/off, but only for Lilygo T5 4.7 board. 

Question is if this should be limited to Lilygo as this shouldn't harm other boards.
 