### PR TITLE
Handle larger fonts

### DIFF
--- a/src/epd_driver/font.c
+++ b/src/epd_driver/font.c
@@ -126,7 +126,7 @@ static enum EpdDrawError IRAM_ATTR draw_char(const EpdFont *font, uint8_t *buffe
   }
 
   uint32_t offset = glyph->data_offset;
-  uint8_t width = glyph->width, height = glyph->height;
+  uint16_t width = glyph->width, height = glyph->height;
   int left = glyph->left;
 
   int byte_width = (width / 2 + width % 2);

--- a/src/epd_driver/include/epd_internals.h
+++ b/src/epd_driver/include/epd_internals.h
@@ -113,9 +113,9 @@ extern const EpdWaveform epdiy_ED133UT2;
 
 /// Font data stored PER GLYPH
 typedef struct {
-  uint8_t width;            ///< Bitmap dimensions in pixels
-  uint8_t height;           ///< Bitmap dimensions in pixels
-  uint8_t advance_x;        ///< Distance to advance cursor (x axis)
+  uint16_t width;            ///< Bitmap dimensions in pixels
+  uint16_t height;           ///< Bitmap dimensions in pixels
+  uint16_t advance_x;        ///< Distance to advance cursor (x axis)
   int16_t left;             ///< X dist from cursor pos to UL corner
   int16_t top;              ///< Y dist from cursor pos to UL corner
   uint16_t compressed_size; ///< Size of the zlib-compressed font data.

--- a/src/epd_driver/include/epd_internals.h
+++ b/src/epd_driver/include/epd_internals.h
@@ -118,7 +118,7 @@ typedef struct {
   uint16_t advance_x;        ///< Distance to advance cursor (x axis)
   int16_t left;             ///< X dist from cursor pos to UL corner
   int16_t top;              ///< Y dist from cursor pos to UL corner
-  uint16_t compressed_size; ///< Size of the zlib-compressed font data.
+  uint32_t compressed_size; ///< Size of the zlib-compressed font data.
   uint32_t data_offset;     ///< Pointer into EpdFont->bitmap
 } EpdGlyph;
 


### PR DESCRIPTION
Unfortunately #147 wasn't quite enough for me (font size 200 for a clock display) - there were a few more 8-bit integers that needed changing to get things displaying properly.

Related to #94 for really big fonts.