### PR TITLE
Lilygo config register should be set to low on poweroff()

### DIFF
--- a/src/epd_driver/config_reg_v2.h
+++ b/src/epd_driver/config_reg_v2.h
@@ -75,9 +75,9 @@ static void cfg_poweroff(epd_config_register_t *cfg) {
   cfg->pos_power_enable = false;
   push_cfg(cfg);
   busy_delay(10 * 240);
-  
+
   cfg->neg_power_enable = false;
-  cfg->pos_power_enable = true;
+  cfg->pos_power_enable = false;
   push_cfg(cfg);
   busy_delay(100 * 240);
 

--- a/src/epd_driver/config_reg_v2.h
+++ b/src/epd_driver/config_reg_v2.h
@@ -75,9 +75,15 @@ static void cfg_poweroff(epd_config_register_t *cfg) {
   cfg->pos_power_enable = false;
   push_cfg(cfg);
   busy_delay(10 * 240);
+  
   cfg->neg_power_enable = false;
+  cfg->pos_power_enable = true;
   push_cfg(cfg);
   busy_delay(100 * 240);
+
+  cfg->ep_stv = false;
+  cfg->ep_output_enable = false;
+  cfg->ep_mode = false;
   cfg->power_disable = true;
   push_cfg(cfg);
   // END POWEROFF


### PR DESCRIPTION
Simple update only for V2

Lilygo config register should be set to low on poweroff() 

Related issue #92