### PR TITLE
added a function epd_get_string_rect into fonts.c

### DIFF
--- a/src/epd_driver/config_reg_v2.h
+++ b/src/epd_driver/config_reg_v2.h
@@ -68,7 +68,6 @@ static void cfg_poweron(epd_config_register_t *cfg) {
 
 static void cfg_poweroff(epd_config_register_t *cfg) {
 #if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
-if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
   // This was re-purposed as power enable.
   cfg->ep_scan_direction = true;
   // POWEROFF

--- a/src/epd_driver/config_reg_v2.h
+++ b/src/epd_driver/config_reg_v2.h
@@ -68,7 +68,29 @@ static void cfg_poweron(epd_config_register_t *cfg) {
 
 static void cfg_poweroff(epd_config_register_t *cfg) {
 #if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
+if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
   // This was re-purposed as power enable.
+  cfg->ep_scan_direction = true;
+  // POWEROFF
+  cfg->pos_power_enable = false;
+  push_cfg(cfg);
+  busy_delay(10 * 240);
+
+  cfg->neg_power_enable = false;
+  cfg->pos_power_enable = false;
+  push_cfg(cfg);
+  busy_delay(100 * 240);
+
+  cfg->ep_stv = false;
+  cfg->ep_output_enable = false;
+  cfg->ep_mode = false;
+  cfg->power_disable = true;
+  push_cfg(cfg);
+  // END POWEROFF
+}
+
+static void cfg_poweroff_all(epd_config_register_t *cfg) {
+   // This was re-purposed as power enable.
   cfg->ep_scan_direction = false;
 #endif
   // POWEROFF

--- a/src/epd_driver/display_ops.c
+++ b/src/epd_driver/display_ops.c
@@ -111,6 +111,13 @@ void epd_poweroff() {
   i2s_gpio_detach();
 }
 
+#if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
+void epd_poweroff_all() {
+  cfg_poweroff_all(&config_reg);
+  i2s_gpio_detach();
+}
+#endif
+
 void epd_base_deinit(){
   epd_poweroff();
   i2s_deinit();

--- a/src/epd_driver/font.c
+++ b/src/epd_driver/font.c
@@ -224,6 +224,36 @@ static void get_char_bounds(const EpdFont *font, uint32_t cp, int *x, int *y,
   *x += glyph->advance_x;
 }
 
+EpdRect epd_get_string_rect (const EpdFont *font, const char *string,
+                     int x, int y, int margin, const EpdFontProperties *properties )
+{
+  assert(properties != NULL);
+  EpdFontProperties props = *properties;
+  props.flags |= EPD_DRAW_BACKGROUND;
+  EpdRect temp  = {.x = x, .y = y, .width = 0, .height = 0};
+  if (*string == '\0') 
+    return temp;
+  int minx = 100000, miny = 100000, maxx = -1, maxy = -1;
+  int temp_x = x;
+  int temp_y = y + font->ascender;
+  
+  // Go through each line and get it's co-ordinates
+  uint32_t c;
+  while ((c = next_cp((const uint8_t **)&string)))
+  {
+    if(c==0x000A) // newline
+    {
+      temp_x = x;
+      temp_y += font->advance_y;
+    }
+    else 
+      get_char_bounds(font, c, &temp_x, &temp_y, &minx, &miny, &maxx, &maxy, &props);
+  }
+  temp.width = maxx - x + ( margin * 2 );
+  temp.height = maxy - miny + ( margin * 2 );
+  return temp;
+}
+
 void epd_get_text_bounds(const EpdFont *font, const char *string,
                      const int *x, const int *y,
                      int *x1, int *y1, int *w, int *h,

--- a/src/epd_driver/include/epd_driver.h
+++ b/src/epd_driver/include/epd_driver.h
@@ -209,6 +209,11 @@ void epd_poweron();
 /** Disable display power supply. */
 void epd_poweroff();
 
+#if defined(CONFIG_EPD_BOARD_REVISION_LILYGO_T5_47)
+/** Disable display power supply completely touch as well */
+void epd_poweroff_all();
+#endif
+
 /** Clear the whole screen by flashing it. */
 void epd_clear();
 
@@ -387,6 +392,18 @@ void epd_get_text_bounds(const EpdFont *font, const char *string,
                      const int *x, const int *y,
                      int *x1, int *y1, int *w, int *h,
                      const EpdFontProperties *props);
+/*!
+ * Returns a rect with the bounds of the text
+ * @param font : the font used to get the character sizes
+ * @param string: pointer to c string
+ * @param x : left most position of rectangle
+ * @param y : top most point of the rectangle
+ * @param margin : to be pllied to the width and height
+ * @returns EpdRect with x and y as per the original and height and width
+ *       adjusted to fit the text with the margin added as well.
+ */ 
+EpdRect epd_get_string_rect (const EpdFont *font, const char *string,
+                     int x, int y, int margin, const EpdFontProperties *properties );
 
 /**
  * Write text to the EPD.


### PR DESCRIPTION
I have added a function epd_get_string_rect into fonts.c 
This allows works with multiple lines and also has a margin parameter to allow simple text area margins.
Unfortunately my rough hack to handle the touch function on the lilygo is also in there.
Both do actually work as expected.
Thanks Greg