### PR TITLE
change boards_local.txt

### DIFF
--- a/boards.local.txt
+++ b/boards.local.txt
@@ -475,8 +475,8 @@ epdiy_v4.menu.DebugLevel.verbose.build.code_debug=5
 lilygo_t5_47.name=LILYGO T5-4.7 inch e-paper
 
 lilygo_t5_47.upload.tool=esp32:esptool_py
-lilygo_t5_47.upload.maximum_size=1310720
-lilygo_t5_47.upload.maximum_data_size=327680
+lilygo_t5_47.upload.maximum_size=6553600
+lilygo_t5_47.upload.maximum_data_size=4521984
 lilygo_t5_47.upload.wait_for_upload_port=true
 lilygo_t5_47.upload.flags=
 lilygo_t5_47.upload.extra_flags=
@@ -498,20 +498,12 @@ lilygo_t5_47.build.flash_freq=80m
 lilygo_t5_47.build.flash_mode=qio
 lilygo_t5_47.build.boot=dio
 lilygo_t5_47.build.partitions=default
-lilygo_t5_47.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
+lilygo_t5_47.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47 -DCONFIG_ARDUINO_ISR_IRAM
 
-lilygo_t5_47.menu.DisplayType.default=ED097OC4
-lilygo_t5_47.menu.DisplayType.default.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED097OC4 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
-lilygo_t5_47.menu.DisplayType.ed097oc4_lq=ED097OC4 Low Quality
-lilygo_t5_47.menu.DisplayType.ed097oc4_lq.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED097OC4_LQ -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
-lilygo_t5_47.menu.DisplayType.ed060sc4=ED060SC4
-lilygo_t5_47.menu.DisplayType.ed060sc4.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED060SC4 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
-lilygo_t5_47.menu.DisplayType.ed097tc2=ED097TC2
-lilygo_t5_47.menu.DisplayType.ed097tc2.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED097TC2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
-lilygo_t5_47.menu.DisplayType.ed047tc1=ED047TC1 (LILYGO 4.7 inch)
-lilygo_t5_47.menu.DisplayType.ed047tc1.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED047TC1 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
-lilygo_t5_47.menu.DisplayType.ed133ut2=ED133UT2
-lilygo_t5_47.menu.DisplayType.ed133ut2.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED133UT2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
+lilygo_t5_47.menu.DisplayType.default=ED047TC1 LILYGO 4.7 inch. Correct grays.
+lilygo_t5_47.menu.DisplayType.default.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED047TC1 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47 -DCONFIG_ARDUINO_ISR_IRAM
+lilygo_t5_47.menu.DisplayType.ed047tc2=ED047TC2 LILYGO 4.7 inch. New waveform, slower and 7 times bigger, darker black
+lilygo_t5_47.menu.DisplayType.ed047tc2.build.defines=-DCONFIG_EPD_DISPLAY_TYPE_ED047TC2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47 -DCONFIG_ARDUINO_ISR_IRAM
 
 lilygo_t5_47.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 lilygo_t5_47.menu.PartitionScheme.default.build.partitions=default


### PR DESCRIPTION
I have modified the lilygo section only. 
I have removed non lilygo screens (seemed pointless and potentially confusing).
I have also changed 
lilygo_t5_47.upload.maximum_size to 6553600
and
lilygo_t5_47.upload.maximum_data_size to 4521984
This sets the compile flag CONFIG_ARDUINO_ISR_IRAM
and as such the ARDUINO_ISR_FLAG is set to ESP_INTR_FLAG_IRAM 
which is 
#define ESP_INTR_FLAG_IRAM          (1<<10) ///< ISR can be called if cache is disabled

There are numerous warnings in the source of how this effects other code though. 
on a linux system
grep -r -A 2 ESP_INTR_FLAG_IRAM ~/.arduino15/packages/esp32/*
will show these. 
specific ones 

i2c.h: *             If the PSRAM is enabled and `intr_flag` is set to `ESP_INTR_FLAG_IRAM`, `data` should be allocated from internal RAM.

timer.h: *       If the intr_alloc_flags value ESP_INTR_FLAG_IRAM is set,
 the handler function must be declared with IRAM_ATTR attribute
 and can only call functions in IRAM or ROM. It cannot call other timer APIs.
 Use direct register access to configure timers from inside the ISR in this case.

This is a file that normally needs to be copied during the original setup of epdiy and as such this change will only occur if the user recopies the file. Somehow this needs to be documented for existing users.