### PR TITLE
Include using full relative path

### DIFF
--- a/src/epd_driver/board/epd_board_v6.c
+++ b/src/epd_driver/board/epd_board_v6.c
@@ -1,5 +1,5 @@
 #include "epd_board.h"
-#include "board/epd_board_v6.h"
+#include "../include/board/epd_board_v6.h"
 
 #include "esp_log.h"
 #include "../display_ops.h"


### PR DESCRIPTION
This is needed by Arduino since it is not yet supported to specify
include directories manually

Fixes #185 