### PR TITLE
add missing st license in terminal example

### DIFF
--- a/examples/terminal/README.md
+++ b/examples/terminal/README.md
@@ -8,3 +8,6 @@ Known Issues:
 - With ESP-IDF 4.0, there is seems to be an issue with the UART 
   leading to missing / delayed data in some cases.
   Seems to be gone in 4.1. Enabling UART ISR in IRAM might help.
+
+## Licese
+- [st](https://st.suckless.org/) is licensed under MIT/X Consortium License (see [`main/LICENSE`](./main/LICENSE)).

--- a/examples/terminal/main/LICENSE
+++ b/examples/terminal/main/LICENSE
@@ -1,0 +1,31 @@
+MIT/X Consortium License
+
+© 2014-2022 Hiltjo Posthuma <hiltjo at codemadness dot org>
+© 2018 Devin J. Pohly <djpohly at gmail dot com>
+© 2014-2017 Quentin Rameau <quinq at fifth dot space>
+© 2009-2012 Aurélien APTEL <aurelien dot aptel at gmail dot com>
+© 2008-2017 Anselm R Garbe <garbeam at gmail dot com>
+© 2012-2017 Roberto E. Vargas Caballero <k0ga at shike2 dot com>
+© 2012-2016 Christoph Lohmann <20h at r-36 dot net>
+© 2013 Eon S. Jeon <esjeon at hyunmu dot am>
+© 2013 Alexander Sedov <alex0player at gmail dot com>
+© 2013 Mark Edgar <medgar123 at gmail dot com>
+© 2013-2014 Eric Pruitt <eric.pruitt at gmail dot com>
+© 2013 Michael Forney <mforney at mforney dot org>
+© 2013-2014 Markus Teich <markus dot teich at stusta dot mhn dot de>
+© 2014-2015 Laslo Hunhold <dev at frign dot de>
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I noticed, that the `st.c` and `st.h` sources in the terminal example [referenced a LICENSE file](https://github.com/vroland/epdiy/blob/master/examples/terminal/main/st.c#L1), although there weren't any.

I tracked back where these files were coming from and found the commit 707c01e4a45df3e3c20256bcea407de981f83423, which references [suckless.org](https://suckless.org/).

To my best knowledge, I used their "MIT/X Consortium License" license.