### PR TITLE
Fixes https://github.com/vroland/epdiy/issues/196

### DIFF
--- a/examples/grayscale_test/main/main.c
+++ b/examples/grayscale_test/main/main.c
@@ -55,6 +55,9 @@ void loop() {
 
   epd_poweron();
   err = epd_hl_update_screen(&hl, MODE_GC16, temperature);
+  if (err != EPD_DRAW_SUCCESS) {
+    printf("Error in epd_hl_update_screen:%d\n", err);
+  }
   epd_poweroff();
 
 

--- a/src/epd_driver/i2s_data_bus.c
+++ b/src/epd_driver/i2s_data_bus.c
@@ -151,7 +151,11 @@ void i2s_gpio_detach(i2s_bus_config *cfg) {
   gpio_set_direction(cfg->clock, GPIO_MODE_INPUT);
 
   gpio_reset_pin(cfg->clock);
-  rtc_gpio_isolate(cfg->clock);
+  if (cfg->clock != 5) {
+    rtc_gpio_isolate(cfg->clock);
+  }
+  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#_CPPv416rtc_gpio_isolate10gpio_num_t
+  rtc_gpio_isolate(GPIO_NUM_12);
 }
 
 void i2s_bus_init(i2s_bus_config *cfg, uint32_t epd_row_width) {


### PR DESCRIPTION
Fixes #196 avoiding to do: 

rtc_gpio_isolate(GPIO_NUM_5);

in the V2 / Lilygo hardware that uses 5 as I2S Clock. On the other models that use number 15 this does not seem to trigger.