### PR TITLE
Feat: Add `epd_hl_update_area_directly` for faster repaint

### DIFF
--- a/src/epd_driver/include/epd_highlevel.h
+++ b/src/epd_driver/include/epd_highlevel.h
@@ -127,6 +127,11 @@ enum EpdDrawError epd_hl_update_screen(EpdiyHighlevelState* state, enum EpdDrawM
 enum EpdDrawError epd_hl_update_area(EpdiyHighlevelState* state, enum EpdDrawMode mode, int temperature, EpdRect area);
 
 /**
+ * @brief Similar to epd_hl_update_area, but no diff with area, to render faster
+ */
+enum EpdDrawError epd_hl_update_area_directly(EpdiyHighlevelState* state, enum EpdDrawMode mode, int temperature, EpdRect area);
+
+/**
  * Reset the front framebuffer to a white state.
  *
  * @param state: A reference to the `EpdiyHighlevelState` object used.


### PR DESCRIPTION
This can greatly reduce the time for repainting, nearly `850ms` for `6 inches` screen.
Without this, you need to do like https://github.com/vroland/epdiy/issues/206, this will cost nearly `1900ms`(with 1 cycle repaint).

Repaint usage:
```c++
  epd_clear_area_cycles(epd_full_screen(), 1, _clear_cycle_time);
  epd_hl_update_area_directly(&hl, updateMode, temperature, epd_full_screen());
```