### PR TITLE
Make GPIO 12 usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following list is compiled from past experiences and GitHub issues:
  * **The existing image fades / darkens when updating a partial screen region.** Make sure the VCOM voltage is [calibrated](https://epdiy.readthedocs.io/en/latest/getting_started.html#calibrate-vcom) for your specific display.
  * **The second third of the image is replaced with the last third.** This seems to be a timing issue we could not yet quite figure out the reason for. For a workarround or suggestions please [join the discussion](https://github.com/vroland/epdiy/issues/15).
  * **The ESP does not boot correctly when external periperals are connected.** Make sure not to pull GPIO12 high during boot, as it is a strapping pin internal voltage selection (https://github.com/vroland/epdiy/issues/17).
+ * **The ESP power consumption in deep sleep is too high.** Add `rtc_gpio_isolate(GPIO_NUM_12);` to your solution. See also <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#_CPPv416rtc_gpio_isolate10gpio_num_t>.
 
 LilyGo Boards
 ---------------

--- a/src/epd_driver/i2s_data_bus.c
+++ b/src/epd_driver/i2s_data_bus.c
@@ -165,7 +165,7 @@ void i2s_gpio_detach(i2s_bus_config *cfg) {
     rtc_gpio_isolate(cfg->clock);
   }
   // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#_CPPv416rtc_gpio_isolate10gpio_num_t
-  #rtc_gpio_isolate(GPIO_NUM_12);
+  // rtc_gpio_isolate(GPIO_NUM_12);
 }
 
 void i2s_bus_init(i2s_bus_config *cfg, uint32_t epd_row_width) {

--- a/src/epd_driver/i2s_data_bus.c
+++ b/src/epd_driver/i2s_data_bus.c
@@ -164,8 +164,6 @@ void i2s_gpio_detach(i2s_bus_config *cfg) {
   if (cfg->clock != 5) {
     rtc_gpio_isolate(cfg->clock);
   }
-  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#_CPPv416rtc_gpio_isolate10gpio_num_t
-  // rtc_gpio_isolate(GPIO_NUM_12);
 }
 
 void i2s_bus_init(i2s_bus_config *cfg, uint32_t epd_row_width) {

--- a/src/epd_driver/i2s_data_bus.c
+++ b/src/epd_driver/i2s_data_bus.c
@@ -165,7 +165,7 @@ void i2s_gpio_detach(i2s_bus_config *cfg) {
     rtc_gpio_isolate(cfg->clock);
   }
   // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#_CPPv416rtc_gpio_isolate10gpio_num_t
-  rtc_gpio_isolate(GPIO_NUM_12);
+  #rtc_gpio_isolate(GPIO_NUM_12);
 }
 
 void i2s_bus_init(i2s_bus_config *cfg, uint32_t epd_row_width) {


### PR DESCRIPTION
The epdiy library disables GPIO 12 on power down/off operation.
Despite GPIO PIN 12 is not being used by any supported board for any operation within this library.

My supported LILYGO® T5-4.7 has only 4 free GPIO (12,13,14,15 - in two connectors on the upper left) and I need all of them.
![LILYGO® T5-4.7](https://m.media-amazon.com/images/S/aplus-media-library-service-media/8a1c326c-2d76-4b35-b74f-05c96acfea0b.__CR0,0,970,600_PT0_SX970_V1___.jpg)

GPIO 12 has limited usage as it is a strapping pin. I am using it as a UART Tx pin and it is working fine. (Cannot use it as UART Rx pin - if pulled high during boot ESP does not detect it has PSRAM).

This PR fixes issue #220 