### PR TITLE
Align dma buffers

### DIFF
--- a/src/epd_driver/board/epd_board_v6.c
+++ b/src/epd_driver/board/epd_board_v6.c
@@ -201,7 +201,16 @@ static void epd_board_poweron(epd_ctrl_state_t *state) {
   // give the IC time to powerup and set lines
   vTaskDelay(1);
 
+  int tries = 0;
   while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    if (tries >= 500) {
+      ESP_LOGE("epdiy", "Power enable failed! INT status: 0x%X 0x%X",
+        tps_read_register(config_reg.port, TPS_REG_INT1),
+        tps_read_register(config_reg.port, TPS_REG_INT2)
+      );
+      return;
+    }
+    tries++;
     vTaskDelay(1);
   }
 
@@ -215,7 +224,6 @@ static void epd_board_poweron(epd_ctrl_state_t *state) {
   };
   epd_board_set_ctrl(state, &mask);
 
-  int tries = 0;
   while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
     if (tries >= 500) {
       ESP_LOGE("epdiy", "Power enable failed! PG status: %X", tps_read_register(config_reg.port, TPS_REG_PG));


### PR DESCRIPTION
The size of the buffers used by DMA must be word aligned. If the width of the display is not aligned we increase the buffer slightly.

For instance the display ED060KC1 has a width of 1448 pixels. The DMA buffer would be 362 bytes (1448/4) and this will not work with the ESP32 DMA driver. Instead the buffer will be increased to 364 bytes.

Also a small fix for faulty boards which made the power on code loop forever.