### PR TITLE
Make it possible to set the display type at runtime

### DIFF
--- a/src/epd_driver/CMakeLists.txt
+++ b/src/epd_driver/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(app_sources "epd_driver.c"
+                "epd_display.c"
                 "epd_board.c"
                 "render.c"
                 "display_ops.c"

--- a/src/epd_driver/Kconfig
+++ b/src/epd_driver/Kconfig
@@ -22,7 +22,7 @@ menu "E-Paper Driver"
 
         config EPD_DISPLAY_TYPE_ED133UT2
             bool "ED133UT2"
-        
+
         config EPD_DISPLAY_TYPE_ED047TC1
             bool "ED047TC1 LILYGO 4.7 inch, correct grays"
         config EPD_DISPLAY_TYPE_ED047TC2
@@ -30,6 +30,9 @@ menu "E-Paper Driver"
 
         config EPD_DISPLAY_TYPE_ED097OC4_LQ
             bool "ED097OC4 Low Quality"
+
+        config EPD_DISPLAY_TYPE_CUSTIOM
+            bool "Set the display type at runtime. A call to epd_set_display() must be called before epd_init()"
     endchoice
 
 

--- a/src/epd_driver/epd_display.c
+++ b/src/epd_driver/epd_display.c
@@ -1,0 +1,11 @@
+#include "epd_display.h"
+
+#include "epd_driver.h"
+#include <stddef.h>
+
+EpdDisplayDefinition epd_display = {0};
+
+void epd_set_display(uint16_t width, uint16_t height) {
+  epd_display.width = width;
+  epd_display.height = height;
+}

--- a/src/epd_driver/epd_driver.c
+++ b/src/epd_driver/epd_driver.c
@@ -25,7 +25,7 @@ static enum EpdRotation display_rotation = EPD_ROT_LANDSCAPE;
 #endif
 
 EpdRect epd_full_screen() {
-  EpdRect area = {.x = 0, .y = 0, .width = EPD_WIDTH, .height = EPD_HEIGHT};
+  EpdRect area = {.x = 0, .y = 0, .width = epd_display.width, .height = epd_display.height};
   return area;
 }
 
@@ -53,15 +53,15 @@ Coord_xy _rotate(uint16_t x, uint16_t y) {
         break;
         case EPD_ROT_PORTRAIT:
             _swap_int(x, y);
-            x = EPD_WIDTH - x - 1;
+            x = epd_display.width - x - 1;
         break;
         case EPD_ROT_INVERTED_LANDSCAPE:
-            x = EPD_WIDTH - x - 1;
-            y = EPD_HEIGHT - y - 1;
+            x = epd_display.width - x - 1;
+            y = epd_display.height - y - 1;
         break;
         case EPD_ROT_INVERTED_PORTRAIT:
             _swap_int(x, y);
-            y = EPD_HEIGHT - y - 1;
+            y = epd_display.height - y - 1;
         break;
     }
     Coord_xy coord = {
@@ -76,14 +76,14 @@ void epd_draw_pixel(int x, int y, uint8_t color, uint8_t *framebuffer) {
   x = coord.x;
   y = coord.y;
 
-  if (x < 0 || x >= EPD_WIDTH) {
+  if (x < 0 || x >= epd_display.width) {
     return;
   }
-  if (y < 0 || y >= EPD_HEIGHT) {
+  if (y < 0 || y >= epd_display.height) {
     return;
   }
 
-  uint8_t *buf_ptr = &framebuffer[y * EPD_WIDTH / 2 + x / 2];
+  uint8_t *buf_ptr = &framebuffer[y * epd_display.width / 2 + x / 2];
   if (x % 2) {
     *buf_ptr = (*buf_ptr & 0x0F) | (color & 0xF0);
   } else {
@@ -351,14 +351,14 @@ void epd_copy_to_framebuffer(EpdRect image_area, const uint8_t *image_data,
                                     : image_data[value_index / 2] & 0x0F;
 
     int xx = image_area.x + i % image_area.width;
-    if (xx < 0 || xx >= EPD_WIDTH) {
+    if (xx < 0 || xx >= epd_display.width) {
       continue;
     }
     int yy = image_area.y + i / image_area.width;
-    if (yy < 0 || yy >= EPD_HEIGHT) {
+    if (yy < 0 || yy >= epd_display.height) {
       continue;
     }
-    uint8_t *buf_ptr = &framebuffer[yy * EPD_WIDTH / 2 + xx / 2];
+    uint8_t *buf_ptr = &framebuffer[yy * epd_display.width / 2 + xx / 2];
     if (xx % 2) {
       *buf_ptr = (*buf_ptr & 0x0F) | (val << 4);
     } else {
@@ -388,13 +388,13 @@ enum EpdRotation epd_get_rotation() {
 }
 
 int epd_rotated_display_width() {
-  int display_width = EPD_WIDTH;
+  int display_width = epd_display.width;
   switch (display_rotation) {
           case EPD_ROT_PORTRAIT:
-              display_width = EPD_HEIGHT;
+              display_width = epd_display.height;
           break;
           case EPD_ROT_INVERTED_PORTRAIT:
-              display_width = EPD_HEIGHT;
+              display_width = epd_display.height;
           break;
           case EPD_ROT_INVERTED_LANDSCAPE:
           case EPD_ROT_LANDSCAPE:
@@ -404,13 +404,13 @@ int epd_rotated_display_width() {
 }
 
 int epd_rotated_display_height() {
-  int display_height = EPD_HEIGHT;
+  int display_height = epd_display.height;
   switch (display_rotation) {
           case EPD_ROT_PORTRAIT:
-              display_height = EPD_WIDTH;
+              display_height = epd_display.width;
           break;
           case EPD_ROT_INVERTED_PORTRAIT:
-              display_height = EPD_WIDTH;
+              display_height = epd_display.width;
           break;
           case EPD_ROT_INVERTED_LANDSCAPE:
           case EPD_ROT_LANDSCAPE:

--- a/src/epd_driver/highlevel.c
+++ b/src/epd_driver/highlevel.c
@@ -20,7 +20,7 @@
 
 static bool already_initialized = 0;
 
-const static int fb_size = EPD_WIDTH / 2 * EPD_HEIGHT;
+static int fb_size = 0;
 
 EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
   assert(!already_initialized);
@@ -29,6 +29,7 @@ EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
   #ifndef CONFIG_ESP32_SPIRAM_SUPPORT
     ESP_LOGW("EPDiy", "Please enable PSRAM for the ESP32 (menuconfig→ Component config→ ESP32-specific)");
   #endif
+  fb_size = epd_display.width / 2 * epd_display.height;
   EpdiyHighlevelState state;
   state.back_fb = heap_caps_malloc(fb_size, MALLOC_CAP_SPIRAM);
   assert(state.back_fb != NULL);
@@ -36,7 +37,7 @@ EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
   assert(state.front_fb != NULL);
   state.difference_fb = heap_caps_malloc(2 * fb_size, MALLOC_CAP_SPIRAM);
   assert(state.difference_fb != NULL);
-  state.dirty_lines = malloc(EPD_HEIGHT * sizeof(bool));
+  state.dirty_lines = malloc(epd_display.height * sizeof(bool));
   assert(state.dirty_lines != NULL);
   state.waveform = waveform;
 
@@ -59,7 +60,7 @@ enum EpdDrawError epd_hl_update_screen(EpdiyHighlevelState* state, enum EpdDrawM
 
 EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
   // If partial update uses full screen do not rotate anything
-  if (!(x == 0 && y == 0 && EPD_WIDTH == w && EPD_HEIGHT == h)) {
+  if (!(x == 0 && y == 0 && epd_display.width == w && epd_display.height == h)) {
     // invert the current display rotation
     switch (epd_get_rotation())
     {
@@ -70,20 +71,20 @@ EpdRect _inverse_rotated_area(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
       case EPD_ROT_PORTRAIT:
         _swap_int(x, y);
         _swap_int(w, h);
-        x = EPD_WIDTH - x - w;
+        x = epd_display.width - x - w;
         break;
 
       case EPD_ROT_INVERTED_LANDSCAPE:
         // 3 180°
-        x = EPD_WIDTH - x - w;
-        y = EPD_HEIGHT - y - h;
+        x = epd_display.width - x - w;
+        y = epd_display.height - y - h;
         break;
 
       case EPD_ROT_INVERTED_PORTRAIT:
         // 3 270 °
         _swap_int(x, y);
         _swap_int(w, h);
-        y = EPD_HEIGHT - y - h;
+        y = epd_display.height - y - h;
         break;
     }
   }
@@ -133,8 +134,8 @@ enum EpdDrawError epd_hl_update_area(EpdiyHighlevelState* state, enum EpdDrawMod
 
   for (int l=diff_area.y; l < diff_area.y + diff_area.height; l++) {
 	if (state->dirty_lines[l] > 0) {
-      uint8_t* lfb = state->front_fb + EPD_WIDTH / 2 * l;
-      uint8_t* lbb = state->back_fb + EPD_WIDTH / 2 * l;
+      uint8_t* lfb = state->front_fb + epd_display.width / 2 * l;
+      uint8_t* lbb = state->back_fb + epd_display.width / 2 * l;
 
       for (int x=diff_area.x; x < diff_area.x + diff_area.width; x++) {
           if (x % 2) {

--- a/src/epd_driver/include/epd_display.h
+++ b/src/epd_driver/include/epd_display.h
@@ -1,0 +1,17 @@
+/**
+ * @file "epd_display.h"
+ * @brief Display-definitions provided by epdiy.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+typedef struct {
+  uint16_t width;
+  uint16_t height;
+} EpdDisplayDefinition;
+
+extern EpdDisplayDefinition epd_display;
+
+void epd_set_display(uint16_t width, uint16_t height);

--- a/src/epd_driver/include/epd_driver.h
+++ b/src/epd_driver/include/epd_driver.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <stdint.h>
 #include "epd_internals.h"
 #include "epd_board.h"
+#include "epd_display.h"
 
 /** Display software rotation.
  *  Sets the rotation for the purposes of the drawing and font functions

--- a/src/epd_driver/include/epd_internals.h
+++ b/src/epd_driver/include/epd_internals.h
@@ -52,7 +52,8 @@
 /// Height of the display area in pixels.
 #define EPD_HEIGHT 540
 #else
-#error "no display type defined!"
+// No display set at compile time, make all buffers as large as the largest supported display
+#define EPD_WIDTH 1600
 #endif
 
 
@@ -148,5 +149,3 @@ typedef struct {
 
 
 #endif // EPD_INTERNALS_H
-
-

--- a/src/epd_driver/lut.h
+++ b/src/epd_driver/lut.h
@@ -8,7 +8,9 @@
 #include "epd_driver.h"
 
 // number of bytes needed for one line of EPD pixel data.
-#define EPD_LINE_BYTES EPD_WIDTH / 4
+#define EPD_LINE_BYTES (epd_display.width / 4)
+// maximum number of line bytes, if needed at compile time.
+#define EPD_MAX_LINE_BYTES (EPD_WIDTH / 4)
 
 ///////////////////////////// Utils /////////////////////////////////////
 


### PR DESCRIPTION
The goal is to be able to support different displays at runtime. I have a use case where one firmware should support more than one display.

This change is a non breaking and backwards compatible addition. It will still be able to select a fixed display using `menuconfig`. If no display is selected the code must call `epd_set_display()` before `epd_init()`, similar to selecting the board at runtime.