### PR TITLE
Fix imageconvert

### DIFF
--- a/scripts/imgconvert.py
+++ b/scripts/imgconvert.py
@@ -17,7 +17,7 @@ args = parser.parse_args()
 im = Image.open(args.inputfile)
 # convert to grayscale
 im = im.convert(mode='L')
-im.thumbnail((args.max_width, args.max_height), Image.ANTIALIAS)
+im.thumbnail((args.max_width, args.max_height), Image.LANCZOS)
 
 # Write out the output file.
 with open(args.outputfile, 'w') as f:


### PR DESCRIPTION
Running: **python imgconvert.py** is returning an error

Because it seems ANTIALIAS is not anymore a valid attribute in Pillow python module.

> Traceback (most recent call last):
>   File "/home/martin/Documents/github/epdiy/scripts/imgconvert.py", line 20, in <module>
>     im.thumbnail((args.max_width, args.max_height), Image.ANTIALIAS)
> AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'

Proposed solution [found here](https://stackoverflow.com/a/76616129):

ANTIALIAS was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.