### PR TITLE
lcd_driver: fix LCD peripheral timing issue caused by ESP-IDF v5.3 API changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           - release-v4.4
           - release-v5.1
           - release-v5.2
+          - release-v5.3
         example:
           - calibration_helper
           - demo

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -518,7 +518,12 @@ static esp_err_t init_lcd_peripheral() {
 
     // enable RGB mode and set data width
     lcd_ll_enable_rgb_mode(lcd.hal.dev, true);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    lcd_ll_set_dma_read_stride(lcd.hal.dev, lcd.config.bus_width);
+    lcd_ll_set_data_wire_width(lcd.hal.dev, lcd.config.bus_width);
+#else
     lcd_ll_set_data_width(lcd.hal.dev, lcd.config.bus_width);
+#endif
     lcd_ll_set_phase_cycles(lcd.hal.dev, 0, (lcd.dummy_bytes > 0), 1);  // enable data phase only
     lcd_ll_enable_output_hsync_in_porch_region(lcd.hal.dev, false);     // enable data phase only
 
@@ -612,7 +617,18 @@ void epd_lcd_set_pixel_clock_MHz(int frequency) {
 
     // set pclk
     int flags = 0;
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    hal_utils_clk_div_t clk_div = {};
+    uint32_t freq
+        = lcd_hal_cal_pclk_freq(&lcd.hal, 240000000, lcd.config.pixel_clock, flags, &clk_div);
+    lcd_ll_set_group_clock_coeff(
+        &LCD_CAM, (int)clk_div.integer, (int)clk_div.denominator, (int)clk_div.numerator
+    );
+#else
     uint32_t freq = lcd_hal_cal_pclk_freq(&lcd.hal, 240000000, lcd.config.pixel_clock, flags);
+#endif
+
     ESP_LOGI(TAG, "pclk freq: %d Hz", freq);
     lcd.line_length_us = (lcd.lcd_res_h + lcd.config.le_high_time + lcd.config.line_front_porch - 1)
                              * 1000000 / lcd.config.pixel_clock


### PR DESCRIPTION
Hi @vroland @martinberlin 

This is the fix of: https://github.com/vroland/epdiy/issues/345

<img width="658" alt="image" src="https://github.com/user-attachments/assets/9d604f14-1927-4c7a-818b-87662f61e4da">

Log see below: 

```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0x9 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce2820,len:0x156c
load:0x403c8700,len:0x4
load:0x403c8704,len:0xe3c
load:0x403cb700,len:0x2f9c
entry 0x403c892c
I (27) boot: ESP-IDF v5.3 2nd stage bootloader
I (27) boot: compile time Aug 26 2024 21:57:11
I (27) boot: Multicore bootloader
I (30) boot: chip revision: v0.2
I (34) qio_mode: Enabling default flash chip QIO
I (39) boot.esp32s3: Boot SPI Speed : 80MHz
I (44) boot.esp32s3: SPI Mode       : QIO
I (48) boot.esp32s3: SPI Flash Size : 2MB
I (53) boot: Enabling RNG early entropy source...
I (58) boot: Partition Table:
I (62) boot: ## Label            Usage          Type ST Offset   Length
I (69) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (77) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (84) boot:  2 factory          factory app      00 00 00010000 00177000
I (92) boot: End of partition table
I (96) esp_image: segment 0: paddr=00010020 vaddr=3c040020 size=1a35ch (107356) map
I (121) esp_image: segment 1: paddr=0002a384 vaddr=3fc93b00 size=026e0h (  9952) load
I (123) esp_image: segment 2: paddr=0002ca6c vaddr=40374000 size=035ach ( 13740) load
I (129) esp_image: segment 3: paddr=00030020 vaddr=42000020 size=35698h (218776) map
I (168) esp_image: segment 4: paddr=000656c0 vaddr=403775ac size=0c4c0h ( 50368) load
I (184) boot: Loaded app from partition at offset 0x10000
I (184) boot: Disabling RNG early entropy source...
I (196) octal_psram: vendor id    : 0x0d (AP)
I (196) octal_psram: dev id       : 0x02 (generation 3)
I (196) octal_psram: density      : 0x03 (64 Mbit)
I (201) octal_psram: good-die     : 0x01 (Pass)
I (206) octal_psram: Latency      : 0x01 (Fixed)
I (212) octal_psram: VCC          : 0x01 (3V)
I (217) octal_psram: SRF          : 0x01 (Fast Refresh)
I (223) octal_psram: BurstType    : 0x01 (Hybrid Wrap)
I (228) octal_psram: BurstLen     : 0x01 (32 Byte)
I (234) octal_psram: Readlatency  : 0x02 (10 cycles@Fixed)
I (240) octal_psram: DriveStrength: 0x00 (1/1)
I (246) MSPI Timing: PSRAM timing tuning index: 5
I (251) esp_psram: Found 8MB PSRAM device
I (255) esp_psram: Speed: 80MHz
I (259) cpu_start: Multicore app
I (553) esp_psram: SPI SRAM memory test OK
I (562) cpu_start: Pro cpu start user code
I (562) cpu_start: cpu freq: 240000000 Hz
I (562) app_init: Application information:
I (565) app_init: Project name:     screen_diag
I (570) app_init: App version:      2.0.0-24-g295160e-dirty
I (576) app_init: Compile time:     Aug 26 2024 21:57:07
I (582) app_init: ELF file SHA256:  8dd0acb342241adf...
I (588) app_init: ESP-IDF:          v5.3
I (593) efuse_init: Min chip rev:     v0.0
I (598) efuse_init: Max chip rev:     v0.99
I (603) efuse_init: Chip rev:         v0.2
I (607) heap_init: Initializing. RAM available for dynamic allocation:
I (615) heap_init: At 3FC96F00 len 00052810 (330 KiB): RAM
I (621) heap_init: At 3FCE9710 len 00005724 (21 KiB): RAM
I (627) heap_init: At 3FCF0000 len 00008000 (32 KiB): DRAM
I (633) heap_init: At 600FE100 len 00001EE8 (7 KiB): RTCRAM
I (639) esp_psram: Adding pool of 8192K of PSRAM memory to heap allocator
I (647) spi_flash: detected chip: gd
I (651) spi_flash: flash io: qio
W (655) spi_flash: Detected size(16384k) larger than the size in the binary image header(2048k). Using the size in the binary image header.
W (668) i2c: This driver is an old driver, please migrate your application code to adapt `driver/i2c_master.h`
I (679) sleep: Configure to isolate all GPIO pins in sleep state
I (686) sleep: Enable automatic switching of GPIO sleep configuration
I (693) main_task: Started on CPU0
I (703) esp_psram: Reserving pool of 32K of internal memory for DMA/internal allocations
I (703) main_task: Calling app_main()
E (713) vfs_fat_spiflash: esp_vfs_fat_spiflash_mount_rw_wl(130): Failed to find FATFS partition (type='data', subtype='fat', partition_label='storage'). Check the partition table.
E (723) screen_diag: Failed to mount FATFS (ESP_ERR_NOT_FOUND)
I (733) epdiy: using resolution 256x768
I (743) gpio: GPIO[45]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0
I (743) epdiy: pclk freq: 20000000 Hz
I (753) epdiy: line width: 14us, 280 cylces
I (753) epdiy: LCD init done.
I (763) epd: Space used for waveform LUT: 64K

Type 'help' to get the list of commands.
Use UP/DOWN arrows to navigate through command history.
Press TAB when typing command name to auto-complete.
I (903) main_task: Returned from app_main()
diag> full_clear_screen
Cleared screen.
diag> draw_rect 0 0 100 100
I (13973) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (14323) epdiy: diff: 26ms, draw: 351ms, buffer update: 2ms, total: 379ms
diag> fill_rect 100 100 100 100
I (31023) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (31383) epdiy: diff: 25ms, draw: 351ms, buffer update: 3ms, total: 379ms
diag> fill_rect 200 200 100 100
I (49993) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (50353) epdiy: diff: 25ms, draw: 351ms, buffer update: 3ms, total: 379ms
diag> write_text -s 300 300 Privyet
I (174623) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (174983) epdiy: diff: 25ms, draw: 351ms, buffer update: 3ms, total: 379ms
diag> write_text -s 300 600 Lay hou!
write_text: excess option hou!
Command returned non-zero error code: 0x1 (ERROR)
diag> write_text -s 300 600 Lay hou
write_text: excess option hou
Command returned non-zero error code: 0x1 (ERROR)
diag> write_text -s 300 600 "Lay hou!"
I (200943) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (201303) epdiy: diff: 25ms, draw: 351ms, buffer update: 3ms, total: 379ms
diag> fill_rect 600 800 100 100
I (223233) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (223593) epdiy: diff: 26ms, draw: 351ms, buffer update: 3ms, total: 380ms
diag> fill_rect 600 600 100 100 0x70
I (263003) epdiy: Using optimized vector implementation on the ESP32-S3, only 1k of 65536 LUT in use!
I (263353) epdiy: diff: 25ms, draw: 352ms, buffer update: 3ms, total: 380ms
diag>
```



Regards,
Jackson