### PR TITLE
Change IDF version reference from 4 to 5

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -76,7 +76,7 @@ First, connect you board with the computer. In the output of :code:`lsusb` you s
 This means the serial adapter is working and there a serial like :code:`/dev/ttyUSB0` should appear.
 
 Next, make sure you have the `Espressif IoT Development Framework <https://github.com/espressif/esp-idf>`_ installed. 
-The current stable (and tested) version is 4.0.
+The current stable (and tested) version is 5.3.
 For instructions on how to get started with the IDF, please refer to their `documentation <https://docs.espressif.com/projects/esp-idf/en/stable/get-started/>`_.
 
 Then, clone the :code:`epdiy` git repository (and its submodules):


### PR DESCRIPTION
Looking at the issues in the project it seems like version 5 is supported. ESP-IDF 5 was released a while ago (first release 2022), and is the target for new development.

I set everything up with my v7 board and ESP-IDF 5.3 and it all seems to work.