### PR TITLE
Minor Bugfixing and support of non 5-bpp waveforms in waveform_hdrgen.py

### DIFF
--- a/scripts/waveform_hdrgen.py
+++ b/scripts/waveform_hdrgen.py
@@ -18,24 +18,37 @@ waveforms = json.load(sys.stdin);
 
 total_size = 0
 
-def phase_to_c(phase):
-    """
-    Convert a 5 bit phase to a 4 bit C LUT.
-    """
-    global total_size
+def phase_to_c(phase,bits_per_pixel_c=4):
+    
+    N1 = len(phase)
+    N2 = len(phase[0])
+    N = 2**bits_per_pixel_c
+   
+    if N1%N != 0:
+        raise ValueError(f"first dimension of phases is {N1}. Allowed are multiples of {N}")
+    
+    step1 = int(N1/N)
+        
+    if N2%N != 0:
+        raise ValueError(f"second dimension of phases is {N2}. Allowed are multiples of {N}")
+    
+    step2 = int(N2/N)
 
     targets = []
-    for t in range(0, 32, 2):
+    for t in range(0, N1, step1):
         chunk = 0
         line = []
-        for f in range(0, 32, 2):
+        i = 0
+        for f in range(0, N2, step2):
             fr = phase[t][f]
             chunk = (chunk << 2) | fr
-            if f and f % 8 == 6:
+            #if f and (f) % 8 == 6:  # true for f == 6, 
+            i += 1
+            if i == 4:
+                i = 0
                 line.append(chunk)
                 chunk = 0
         targets.append(line)
-        total_size += len(line)
 
     return targets
 
@@ -61,7 +74,7 @@ if args.temperature_range:
 
 modes = []
 
-mode_filter = list(range(len(waveforms["modes"])))
+mode_filter = [wm["mode"] for wm in waveforms["modes"]]
 
 if args.export_modes:
     mode_filter = list(map(int, args.export_modes.split(",")))
@@ -72,6 +85,8 @@ num_modes = len(mode_filter)
 
 temp_intervals = []
 for bounds in waveforms["temperature_ranges"]["range_bounds"]:
+    if bounds["from"] < tmin or bounds["from"] > tmax:
+        continue
     temp_intervals.append(f"{{ .min = {bounds['from']}, .max = {bounds['to']} }}")
 
 modes = []

--- a/scripts/waveform_hdrgen.py
+++ b/scripts/waveform_hdrgen.py
@@ -42,7 +42,6 @@ def phase_to_c(phase,bits_per_pixel_c=4):
         for f in range(0, N2, step2):
             fr = phase[t][f]
             chunk = (chunk << 2) | fr
-            #if f and (f) % 8 == 6:  # true for f == 6, 
             i += 1
             if i == 4:
                 i = 0

--- a/scripts/waveform_hdrgen.py
+++ b/scripts/waveform_hdrgen.py
@@ -84,7 +84,7 @@ num_modes = len(mode_filter)
 
 temp_intervals = []
 for bounds in waveforms["temperature_ranges"]["range_bounds"]:
-    if bounds["from"] < tmin or bounds["from"] > tmax:
+    if bounds["to"] < tmin or bounds["from"] > tmax:
         continue
     temp_intervals.append(f"{{ .min = {bounds['from']}, .max = {bounds['to']} }}")
 
@@ -98,7 +98,7 @@ for m_index, mode in enumerate(waveforms["modes"]):
     ranges = []
     for i, r in enumerate(mode["ranges"]):
         bounds = waveforms["temperature_ranges"]["range_bounds"][i]
-        if bounds["from"] < tmin or bounds["from"] > tmax:
+        if bounds["to"] < tmin or bounds["from"] > tmax:
             continue
 
         phases = []

--- a/src/highlevel.c
+++ b/src/highlevel.c
@@ -172,12 +172,12 @@ enum EpdDrawError epd_hl_update_area(
                 x += 1;
             }
 
-            if (x_last % 2) {
+            if (!(x_last % 2)) {
                 *(lbb + x_last / 2) = (*(lfb + x_last / 2) & 0x0F) | (*(lbb + x_last / 2) & 0xF0);
                 x_last -= 1;
             }
 
-            memcpy(lbb + (x / 2), lfb + (x / 2), (x_last - x) / 2);
+            memcpy(lbb + (x / 2), lfb + (x / 2), (x_last - x + 1) / 2);
         }
     }
 

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -653,7 +653,7 @@ void IRAM_ATTR epd_lcd_start_frame() {
         lcd.lcd_res_h + (lcd.dummy_bytes > 0),
         end_line
     );
-    lcd_ll_set_vertical_timing(lcd.hal.dev, 1, 1, initial_lines, 1);
+    lcd_ll_set_vertical_timing(lcd.hal.dev, 1, 0, initial_lines, 1);
 
     // generate the hsync at the very beginning of line
     lcd_ll_set_hsync_position(lcd.hal.dev, 1);


### PR DESCRIPTION
This pull request addresses two issues: 

1. Issue [326](https://github.com/vroland/epdiy/issues/326) describes:
- Last pixel in line not updated 
- Framebuffer shifted by one row on display (first row on display not updated)

2. Issue [377](https://github.com/vroland/epdiy/issues/377) describes minor bugs and improvements in waveform_hdrgen.py:
- Default mode_filter is wrong
- Temperature interval is too long if temperature range is limited
- Approach to support non 5-bpp waveforms