### PR TITLE
Adding new supported display ED052TC4 1280x780

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Displays
 |ED047TC1|4.7"|960 x 540<br>234 PPI|yes, tested|40-pin|40|LILYGO 4.7" EPD|Supported only by 4.7" e-paper board by LILYGO
 | ED050SC5 | 5" | 600 x 800<br>200 PPI | yes, tested       | THD0510-33CL-GF | 33 | v5 |
 | ED050SC3 | 5" | 600 x 800<br>200 PPI | yes (should work) | THD0510-33CL-GF | 33 | v5 |
+| ED052TC4 | 5.2" | 1280 x 780<br>??? PPI | yes (should work) | WP27D-P050VA3 | 50 | v5 |
 | ED133UT2 | 13.3" | 1600 x 1200<br>150 PPI | yes, tested | adapter board | 39 | v2 | Adapter Board required, also PENG133D
 | ED060XC3 | 6" | 758 x 1024<br>212 PPI | yes, tested | THD0515-34CL-SN | 34 | v5 | Cheapest, good contrast and resolution
 | ED060XD4 | 6"  | 758 x 1024<br>212 PPI | yes, tested | THD0515-34CL-SN | 34 | v5 |

--- a/examples/www-image/main/CMakeLists.txt
+++ b/examples/www-image/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(        
-    app_sources "jpg-render.c"
-    #app_sources "jpgdec-render.cpp"
+    #app_sources "jpg-render.c"
+    app_sources "jpgdec-render.cpp"
     )
 
 idf_component_register(SRCS ${app_sources} 

--- a/examples/www-image/main/settings.h
+++ b/examples/www-image/main/settings.h
@@ -2,6 +2,8 @@
 #define ESP_WIFI_SSID ""
 #define ESP_WIFI_PASSWORD ""
 
+// Define DISPLAY
+#define EPD_DISPLAY ED052TC4
 // Affects the gamma to calculate gray (lower is darker/higher contrast)
 // Nice test values: 0.9 1.2 1.4 higher and is too bright
 double gamma_value = 0.7;
@@ -18,7 +20,7 @@ double gamma_value = 0.7;
 
 // Image URL and jpg settings. Make sure to update WIDTH/HEIGHT if using loremflickr
 // Note: Only HTTP protocol supported (Check README to use SSL secure URLs) loremflickr
-#define IMG_URL ("https://loremflickr.com/1024/768")
+#define IMG_URL ("http://img.cale.es/jpg/fasani/5ea1dec401890")
 
 // idf >= 4.3 needs VALIDATE_SSL_CERTIFICATE set to true for https URLs
 // Please check the README to understand how to use an SSL Certificate
@@ -27,7 +29,7 @@ double gamma_value = 0.7;
 // verification
 //            heading ESP-TLS in
 //            https://newreleases.io/project/github/espressif/esp-idf/release/v4.3-beta1
-#define VALIDATE_SSL_CERTIFICATE true
+#define VALIDATE_SSL_CERTIFICATE false
 // To make an insecure request please check Readme
 
 // Alternative non-https URL:

--- a/examples/www-image/main/settings.h
+++ b/examples/www-image/main/settings.h
@@ -1,6 +1,6 @@
 // WiFi configuration:
-#define ESP_WIFI_SSID ""
-#define ESP_WIFI_PASSWORD ""
+#define ESP_WIFI_SSID "ssid"
+#define ESP_WIFI_PASSWORD "pass"
 
 // Define DISPLAY
 #define EPD_DISPLAY ED052TC4
@@ -20,7 +20,8 @@ double gamma_value = 0.7;
 
 // Image URL and jpg settings. Make sure to update WIDTH/HEIGHT if using loremflickr
 // Note: Only HTTP protocol supported (Check README to use SSL secure URLs) loremflickr
-#define IMG_URL ("http://img.cale.es/jpg/fasani/5ea1dec401890")
+#define IMG_URL ("https://loremflickr.com/1080/780")
+//#define IMG_URL ("http://img.cale.es/jpg/fasani/5ea1dec401890")
 
 // idf >= 4.3 needs VALIDATE_SSL_CERTIFICATE set to true for https URLs
 // Please check the README to understand how to use an SSL Certificate
@@ -29,7 +30,7 @@ double gamma_value = 0.7;
 // verification
 //            heading ESP-TLS in
 //            https://newreleases.io/project/github/espressif/esp-idf/release/v4.3-beta1
-#define VALIDATE_SSL_CERTIFICATE false
+#define VALIDATE_SSL_CERTIFICATE true
 // To make an insecure request please check Readme
 
 // Alternative non-https URL:

--- a/examples/www-image/main/settings.h
+++ b/examples/www-image/main/settings.h
@@ -21,7 +21,6 @@ double gamma_value = 0.7;
 // Image URL and jpg settings. Make sure to update WIDTH/HEIGHT if using loremflickr
 // Note: Only HTTP protocol supported (Check README to use SSL secure URLs) loremflickr
 #define IMG_URL ("https://loremflickr.com/1080/780")
-//#define IMG_URL ("http://img.cale.es/jpg/fasani/5ea1dec401890")
 
 // idf >= 4.3 needs VALIDATE_SSL_CERTIFICATE set to true for https URLs
 // Please check the README to understand how to use an SSL Certificate

--- a/src/displays.c
+++ b/src/displays.c
@@ -79,5 +79,5 @@ const EpdDisplay_t ED052TC4 = {
     .bus_width = 8,
     .bus_speed = 22,
     .default_waveform = &epdiy_ED097TC2,
-    .display_type = DISPLAY_TYPE_ED097TC2
+    .display_type = DISPLAY_TYPE_ED097TC2,
 };

--- a/src/displays.c
+++ b/src/displays.c
@@ -71,3 +71,13 @@ const EpdDisplay_t ED078KC1 = {
     .default_waveform = &epdiy_ED047TC2,
     .display_type = DISPLAY_TYPE_GENERIC,
 };
+
+// Attention is by default horizontal rows mirrored
+const EpdDisplay_t ED052TC4 = {
+    .width = 1280,
+    .height = 720,
+    .bus_width = 8,
+    .bus_speed = 22,
+    .default_waveform = &epdiy_ED097TC2,
+    .display_type = DISPLAY_TYPE_ED097TC2
+};

--- a/src/epd_display.h
+++ b/src/epd_display.h
@@ -40,3 +40,4 @@ extern const EpdDisplay_t ED133UT2;
 extern const EpdDisplay_t ED047TC1;
 extern const EpdDisplay_t ED047TC2;
 extern const EpdDisplay_t ED078KC1;
+extern const EpdDisplay_t ED052TC4;


### PR DESCRIPTION
Adding this nice and cheap display (17€ in Aliexpress)
Similar to Lilygo EPD47 but slightly bigger and more resolution. Grays work but only 9 scales or so, probably needs better gray matrix. I will stop calling it waveforms since it's actually a 2 bit data stream, with transitions from Gray1 to Gray2 :D
More grays but still not perfect using the Lilygo ED0457TC2 double passes waveform file.

ADAPTER Kicad files:
https://github.com/martinberlin/epdiy-hardware-versions/tree/main/adapters/40_to_WP27D-P050VA3

![IMG_3218](https://github.com/user-attachments/assets/e9dd6fce-42c4-440c-8810-afab1b1e4a8d)
![camphoto_126398554 rotated](https://github.com/user-attachments/assets/17343b38-79b9-4444-9136-c0bf0d66eb42)

In this update I'm also adding some fixes to my www-image example:

- Moving display into settings.h so you don't have to touch the main file
- Updating logging related errors (The usual this is not an (int) or not a large int)