### PR TITLE
Fix build on ESP-IDF 5.4, drop 4.x support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     container:
-      image: "espressif/idf:release-v5.3"
+      image: "espressif/idf:release-v5.4"
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -22,19 +22,22 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - release-v4.4
-          - release-v5.1
           - release-v5.2
           - release-v5.3
+          - release-v5.4
+        target:
+          - esp32
+          - esp32s3
         example:
-          - calibration_helper
           - demo
-          - dragon
-          - grayscale_test
-          - www-image
         include:
-          - version: release-v5.1
-            example: screen_diag
+          - version: release-v5.4
+            example: 
+              - screen_diag
+              - dragon
+              - grayscale_test
+              - www-image
+              - calibration_helper
 
     continue-on-error: ${{ matrix.version == 'latest' }}
 
@@ -45,6 +48,7 @@ jobs:
       - uses: 'espressif/esp-idf-ci-action@main'
         with:
           esp_idf_version: ${{ matrix.version }}
+          target: ${{ matrix.target }}
           path: 'examples/${{ matrix.example }}'
 
   build-arduino:
@@ -55,12 +59,12 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - release-v4.4
+          - release-v5.3
         example:
           - weather
         include:
-          - version: release-v4.4
-            arduino-esp32: 2.0.11
+          - version: release-v3.1.3
+            arduino-esp32: 3.1.3
 
     steps:
       - name: Install latest git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,5 +83,6 @@ jobs:
         run: |
           . $IDF_PATH/export.sh
           cd examples/${{ matrix.example }}
+          idf.py set-target esp32s3
           idf.py build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - v5.3
+          - v5.3.2
         example:
           - weather
         arduino-esp32: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,12 +62,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - release-v5.3
+          - release-v5.3.2
         example:
           - weather
-        include:
-          - version: release-v3.1.3
-            arduino-esp32: 3.1.3
+        arduino-esp32: 
+          - 3.1.3 
 
     steps:
       - name: Install latest git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,15 @@ jobs:
           - demo
         include:
           - version: release-v5.4
-            example: 
-              - screen_diag
-              - dragon
-              - grayscale_test
-              - www-image
-              - calibration_helper
+            example: screen_diag
+          - version: release-v5.4
+            example: dragon
+          - version: release-v5.4
+            example: grayscale_test
+          - version: release-v5.4
+            example: www-image
+          - version: release-v5.4
+            example: calibration_helper
 
     continue-on-error: ${{ matrix.version == 'latest' }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - release-v5.3
+          - v5.3
         example:
           - weather
         arduino-esp32: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     container:
-      image: "espressif/idf:release-v5.4"
+      image: "espressif/idf:v5.4"
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -22,24 +22,24 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - release-v5.2
-          - release-v5.3
-          - release-v5.4
+          - v5.2
+          - v5.3
+          - v5.4
         target:
           - esp32
           - esp32s3
         example:
           - demo
         include:
-          - version: release-v5.4
+          - version: v5.4
             example: screen_diag
-          - version: release-v5.4
+          - version: v5.4
             example: dragon
-          - version: release-v5.4
+          - version: v5.4
             example: grayscale_test
-          - version: release-v5.4
+          - version: v5.4
             example: www-image
-          - version: release-v5.4
+          - version: v5.4
             example: calibration_helper
 
     continue-on-error: ${{ matrix.version == 'latest' }}
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - release-v5.3.2
+          - release-v5.3
         example:
           - weather
         arduino-esp32: 

--- a/examples/weather/main/ArduinoJson.h
+++ b/examples/weather/main/ArduinoJson.h
@@ -4546,8 +4546,8 @@ struct BoundedReader<TSource*, typename enable_if<IsCharOrVoid<TSource>::value>:
    public:
     explicit BoundedReader(const void* ptr, size_t len)
         : IteratorReader<const char*>(
-            reinterpret_cast<const char*>(ptr), reinterpret_cast<const char*>(ptr) + len
-        ) {}
+              reinterpret_cast<const char*>(ptr), reinterpret_cast<const char*>(ptr) + len
+          ) {}
 };
 template <typename TArray>
 struct Reader<ElementProxy<TArray>, void> : Reader<char*, void> {

--- a/examples/weather/main/weather.cpp
+++ b/examples/weather/main/weather.cpp
@@ -231,7 +231,7 @@ uint8_t StartWiFi() {
     IPAddress dns(8, 8, 8, 8);  // Google DNS
     WiFi.disconnect();
     WiFi.mode(WIFI_STA);  // switch off AP
-    WiFi.setAutoConnect(true);
+    // Deprecated? WiFi.setAutoConnect(true);
     WiFi.setAutoReconnect(true);
     WiFi.begin(ssid, password);
     unsigned long start = millis();
@@ -313,7 +313,7 @@ void setup() {
             volatile uint32_t t1 = Millis();
             epd_clear();
             volatile uint32_t t2 = Millis();
-            printf("EPD clear took %dms.\n", t2 - t1);
+            printf("EPD clear took %ldms.\n", t2 - t1);
 
             // epd_poweroff();
             // epd_poweron();

--- a/examples/www-image/main/jpg-render.c
+++ b/examples/www-image/main/jpg-render.c
@@ -190,10 +190,10 @@ void deepsleep() {
     esp_deep_sleep(1000000LL * 60 * DEEPSLEEP_MINUTES_AFTER_RENDER);
 }
 
-static uint32_t feed_buffer(
+static unsigned int feed_buffer(
     JDEC* jd,
-    uint8_t* buff,  // Pointer to the read buffer (NULL:skip)
-    uint32_t nd
+    unsigned char* buff,  // Pointer to the read buffer (NULL:skip)
+    unsigned int nd
 ) {
     uint32_t count = 0;
 
@@ -209,7 +209,7 @@ static uint32_t feed_buffer(
 }
 
 /* User defined call-back function to output decoded RGB bitmap in decoded_image buffer */
-static uint32_t tjd_output(
+static unsigned int tjd_output(
     JDEC* jd,     /* Decompressor object of current session */
     void* bitmap, /* Bitmap data to be output */
     JRECT* rect   /* Rectangular region to output */

--- a/examples/www-image/main/jpg-render.c
+++ b/examples/www-image/main/jpg-render.c
@@ -367,15 +367,14 @@ static void http_post(void) {
      * either in URL or as host and path parameters.
      * FIX: Uncommenting cert_pem restarts even if providing the right certificate
      */
-    esp_http_client_config_t config
-        = {.url = IMG_URL,
-           .event_handler = _http_event_handler,
-           .buffer_size = HTTP_RECEIVE_BUFFER_SIZE,
-           .disable_auto_redirect = false,
+    esp_http_client_config_t config = { .url = IMG_URL,
+                                        .event_handler = _http_event_handler,
+                                        .buffer_size = HTTP_RECEIVE_BUFFER_SIZE,
+                                        .disable_auto_redirect = false,
 #if VALIDATE_SSL_CERTIFICATE == true
-           .cert_pem = (char*)server_cert_pem_start
+                                        .cert_pem = (char*)server_cert_pem_start
 #endif
-          };
+    };
     esp_http_client_handle_t client = esp_http_client_init(&config);
 
 #if DEBUG_VERBOSE

--- a/examples/www-image/main/jpgdec-render.cpp
+++ b/examples/www-image/main/jpgdec-render.cpp
@@ -284,14 +284,13 @@ static void http_post(void) {
      * NOTE: All the configuration parameters for http_client must be specified
      * either in URL or as host and path parameters.
      */
-    esp_http_client_config_t config
-        = {.url = IMG_URL,
+    esp_http_client_config_t config = { .url = IMG_URL,
 #if VALIDATE_SSL_CERTIFICATE == true
-           .cert_pem = (char*)server_cert_pem_start,
+                                        .cert_pem = (char*)server_cert_pem_start,
 #endif
-           .disable_auto_redirect = false,
-           .event_handler = _http_event_handler,
-           .buffer_size = HTTP_RECEIVE_BUFFER_SIZE };
+                                        .disable_auto_redirect = false,
+                                        .event_handler = _http_event_handler,
+                                        .buffer_size = HTTP_RECEIVE_BUFFER_SIZE };
 
     esp_http_client_handle_t client = esp_http_client_init(&config);
 

--- a/src/font.c
+++ b/src/font.c
@@ -5,11 +5,7 @@
 
 #include "epdiy.h"
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-#include "rom/miniz.h"
-#else
 #include <miniz.h>
-#endif
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/output_common/lut.c
+++ b/src/output_common/lut.c
@@ -9,10 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "esp_system.h"  // for ESP_IDF_VERSION_VAL
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "esp_timer.h"
-#endif
 
 /*
  * Build Lookup tables and translate via LUTs.

--- a/src/output_common/render_context.h
+++ b/src/output_common/render_context.h
@@ -105,5 +105,6 @@ void prepare_context_for_next_frame(RenderContext_t* ctx);
  *
  * don't inline for to ensure availability in tests.
  */
-void __attribute__((noinline))
-epd_populate_line_mask(uint8_t* line_mask, const uint8_t* dirty_columns, int mask_len);
+void __attribute__((noinline)) epd_populate_line_mask(
+    uint8_t* line_mask, const uint8_t* dirty_columns, int mask_len
+);

--- a/src/output_i2s/i2s_data_bus.c
+++ b/src/output_i2s/i2s_data_bus.c
@@ -21,11 +21,7 @@
 #include "soc/rtc.h"
 
 #include "esp_system.h"  // for ESP_IDF_VERSION_VAL
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "esp_private/periph_ctrl.h"
-#else
-#include "driver/periph_ctrl.h"
-#endif
 
 /// DMA descriptors for front and back line buffer.
 /// We use two buffers, so one can be filled while the other
@@ -214,12 +210,8 @@ void i2s_bus_init(i2s_bus_config* cfg, uint32_t epd_row_width) {
     dev->sample_rate_conf.tx_bck_div_num = 2;
 
     // Initialize Audio Clock (APLL)
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     rtc_clk_apll_enable(true);
     rtc_clk_apll_coeff_set(0, 0, 0, 8);
-#else
-    rtc_clk_apll_enable(1, 0, 0, 8, 0);
-#endif
 
     // Set Audio Clock Dividers
     dev->clkm_conf.val = 0;
@@ -302,12 +294,8 @@ void i2s_bus_deinit() {
     free((void*)i2s_state.dma_desc_a);
     free((void*)i2s_state.dma_desc_b);
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     rtc_clk_apll_coeff_set(0, 0, 0, 8);
     rtc_clk_apll_enable(true);
-#else
-    rtc_clk_apll_enable(0, 0, 0, 8, 0);
-#endif
 
     periph_module_disable(PERIPH_I2S1_MODULE);
 }

--- a/src/output_i2s/render_i2s.h
+++ b/src/output_i2s/render_i2s.h
@@ -3,10 +3,8 @@
 #include <driver/gpio.h>
 #include <esp_assert.h>
 #include <esp_system.h>
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include <hal/gpio_ll.h>
 #include <soc/gpio_struct.h>
-#endif
 
 #include "../output_common/render_context.h"
 #include "sdkconfig.h"
@@ -42,12 +40,8 @@ void i2s_deinit();
  */
 inline void fast_gpio_set_hi(gpio_num_t gpio_num) {
 #ifdef CONFIG_IDF_TARGET_ESP32
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     gpio_dev_t* device = GPIO_LL_GET_HW(GPIO_PORT_0);
     device->out_w1ts = (1 << gpio_num);
-#else
-    GPIO.out_w1ts = (1 << gpio_num);
-#endif
 #else
     // not supportd on non ESP32 chips
     assert(false);
@@ -56,12 +50,8 @@ inline void fast_gpio_set_hi(gpio_num_t gpio_num) {
 
 inline void fast_gpio_set_lo(gpio_num_t gpio_num) {
 #ifdef CONFIG_IDF_TARGET_ESP32
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     gpio_dev_t* device = GPIO_LL_GET_HW(GPIO_PORT_0);
     device->out_w1tc = (1 << gpio_num);
-#else
-    GPIO.out_w1tc = (1 << gpio_num);
-#endif
 #else
     // not supportd on non ESP32 chips
     assert(false);

--- a/src/output_i2s/rmt_pulse.c
+++ b/src/output_i2s/rmt_pulse.c
@@ -4,7 +4,6 @@
 #ifdef RENDER_METHOD_I2S
 
 #include "driver/rmt.h"
-#include "esp_system.h"
 #include "rmt_pulse.h"
 
 #include "soc/rmt_struct.h"
@@ -25,7 +24,6 @@ static void IRAM_ATTR rmt_interrupt_handler(void* arg) {
     RMT.int_clr.val = RMT.int_st.val;
 }
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 // The extern line is declared in esp-idf/components/driver/deprecated/rmt_legacy.c. It has access
 // to RMTMEM through the rmt_private.h header which we can't access outside the sdk. Declare our own
 // extern here to properly use the RMTMEM smybol defined in
@@ -33,7 +31,6 @@ static void IRAM_ATTR rmt_interrupt_handler(void* arg) {
 // old rmt_block_mem_t struct. Same data fields, different names
 typedef rmt_mem_t rmt_block_mem_t;
 extern rmt_block_mem_t RMTMEM;
-#endif
 
 void rmt_pulse_init(gpio_num_t pin) {
     row_rmt_config.rmt_mode = RMT_MODE_TX;
@@ -52,9 +49,6 @@ void rmt_pulse_init(gpio_num_t pin) {
     row_rmt_config.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
     row_rmt_config.tx_config.idle_output_en = true;
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 2, 0) && ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(4, 0, 2)
-#error "This driver is not compatible with IDF version 4.1.\nPlease use 4.0 or >= 4.2!"
-#endif
     esp_intr_alloc(
         ETS_RMT_INTR_SOURCE, ESP_INTR_FLAG_LEVEL3, rmt_interrupt_handler, 0, &gRMT_intr_handle
     );

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -18,20 +18,12 @@
 #include <stdio.h>
 #include <string.h>
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include <driver/rmt_tx.h>
 #include <driver/rmt_types.h>
 #include <driver/rmt_types_legacy.h>
 #include <esp_private/periph_ctrl.h>
 #include <hal/rmt_types.h>
 #include <soc/clk_tree_defs.h>
-#else
-#include <driver/periph_ctrl.h>
-#include <driver/rmt.h>
-#include <esp_rom_gpio.h>
-#include <soc/rmt_struct.h>
-#include "idf-4-backports.h"
-#endif
 
 #include <driver/gpio.h>
 #include <esp_check.h>
@@ -76,7 +68,6 @@ static inline int max(int x, int y) {
 
 #define RMT_CKV_CHAN RMT_CHANNEL_1
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 // The extern line is declared in esp-idf/components/driver/deprecated/rmt_legacy.c. It has access
 // to RMTMEM through the rmt_private.h header which we can't access outside the sdk. Declare our own
 // extern here to properly use the RMTMEM smybol defined in
@@ -84,7 +75,6 @@ static inline int max(int x, int y) {
 // old rmt_block_mem_t struct. Same data fields, different names
 typedef rmt_mem_t rmt_block_mem_t;
 extern rmt_block_mem_t RMTMEM;
-#endif
 
 // spinlock for protecting the critical section at frame start
 static portMUX_TYPE frame_start_spinlock = portMUX_INITIALIZER_UNLOCKED;
@@ -191,13 +181,7 @@ static void init_ckv_rmt() {
 
     // Divide 80MHz APB Clock by 8 -> .1us resolution delay
     // idf >= 5.0 calculates the clock divider differently
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     rmt_ll_set_group_clock_src(&RMT, RMT_CKV_CHAN, RMT_CLK_SRC_DEFAULT, 1, 0, 0);
-#else
-    rmt_ll_set_group_clock_src(
-        &RMT, RMT_CKV_CHAN, (rmt_clock_source_t)RMT_BASECLK_DEFAULT, 0, 0, 0
-    );
-#endif
     rmt_ll_tx_set_channel_clock_div(&RMT, RMT_CKV_CHAN, 8);
     rmt_ll_tx_set_mem_blocks(&RMT, RMT_CKV_CHAN, 2);
     rmt_ll_enable_mem_access_nonfifo(&RMT, true);
@@ -524,12 +508,8 @@ static esp_err_t init_lcd_peripheral() {
 
     // enable RGB mode and set data width
     lcd_ll_enable_rgb_mode(lcd.hal.dev, true);
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     lcd_ll_set_dma_read_stride(lcd.hal.dev, lcd.config.bus_width);
     lcd_ll_set_data_wire_width(lcd.hal.dev, lcd.config.bus_width);
-#else
-    lcd_ll_set_data_width(lcd.hal.dev, lcd.config.bus_width);
-#endif
     lcd_ll_set_phase_cycles(lcd.hal.dev, 0, (lcd.dummy_bytes > 0), 1);  // enable data phase only
     lcd_ll_enable_output_hsync_in_porch_region(lcd.hal.dev, false);     // enable data phase only
 

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -508,8 +508,12 @@ static esp_err_t init_lcd_peripheral() {
 
     // enable RGB mode and set data width
     lcd_ll_enable_rgb_mode(lcd.hal.dev, true);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     lcd_ll_set_dma_read_stride(lcd.hal.dev, lcd.config.bus_width);
     lcd_ll_set_data_wire_width(lcd.hal.dev, lcd.config.bus_width);
+#else
+    lcd_ll_set_data_width(lcd.hal.dev, lcd.config.bus_width);
+#endif
     lcd_ll_set_phase_cycles(lcd.hal.dev, 0, (lcd.dummy_bytes > 0), 1);  // enable data phase only
     lcd_ll_enable_output_hsync_in_porch_region(lcd.hal.dev, false);     // enable data phase only
 

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -47,7 +47,7 @@
 
 #define TAG "epdiy"
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0)
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2)
 #define LCD_PERIPH_SIGNALS lcd_periph_signals
 #else
 #define LCD_PERIPH_SIGNALS lcd_periph_rgb_signals


### PR DESCRIPTION
Adds the necessary fixes to work with IDF 5.4. Additionally, we drop support for ESP-IDF < 5.0, as 5.X is now adopted almost everywhere.