### PR TITLE
IDF 5.5 compatibility: Replace gpio_hal_iomux_func_sel

### DIFF
--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -45,6 +45,10 @@
 #include <soc/lcd_periph.h>
 #include <soc/rmt_struct.h>
 
+#include "hal/gpio_hal.h"
+
+gpio_hal_context_t hal = { .dev = GPIO_HAL_GET_HW(GPIO_PORT_0) };
+
 #define TAG "epdiy"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2)
@@ -190,7 +194,7 @@ static void init_ckv_rmt() {
 
     rmt_ll_tx_enable_loop(&RMT, RMT_CKV_CHAN, true);
 
-    gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[lcd.config.bus.ckv], PIN_FUNC_GPIO);
+    gpio_hal_func_sel(&hal, lcd.config.bus.ckv, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.ckv, GPIO_MODE_OUTPUT);
     esp_rom_gpio_connect_out_signal(
         lcd.config.bus.ckv, rmt_periph_signals.groups[0].channels[RMT_CKV_CHAN].tx_sig, false, 0
@@ -323,17 +327,17 @@ static esp_err_t init_bus_gpio() {
 
     // connect peripheral signals via GPIO matrix
     for (size_t i = (16 - lcd.config.bus_width); i < 16; i++) {
-        gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[DATA_LINES[i]], PIN_FUNC_GPIO);
+        gpio_hal_func_sel(&hal, DATA_LINES[i], PIN_FUNC_GPIO);
         gpio_set_direction(DATA_LINES[i], GPIO_MODE_OUTPUT);
         esp_rom_gpio_connect_out_signal(
             DATA_LINES[i], LCD_PERIPH_SIGNALS.panels[0].data_sigs[i], false, false
         );
     }
-    gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[lcd.config.bus.leh], PIN_FUNC_GPIO);
+    gpio_hal_func_sel(&hal, lcd.config.bus.leh, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.leh, GPIO_MODE_OUTPUT);
-    gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[lcd.config.bus.clock], PIN_FUNC_GPIO);
+    gpio_hal_func_sel(&hal, lcd.config.bus.clock, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.clock, GPIO_MODE_OUTPUT);
-    gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[lcd.config.bus.start_pulse], PIN_FUNC_GPIO);
+    gpio_hal_func_sel(&hal, lcd.config.bus.start_pulse, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.start_pulse, GPIO_MODE_OUTPUT);
 
     esp_rom_gpio_connect_out_signal(


### PR DESCRIPTION
This PR allows you to compile EPDiy with ESP-IDF 5.5.

`gpio_hal_iomux_func_sel()` was removed in ESP IDF 5.5.
https://github.com/espressif/esp-idf/commit/222b1ddbabfb921027a22787b8f19c1d1520011d

