### PR TITLE
Add ESP-IDF 6.0 support with dual 5.x/6.x compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           - v5.2
           - v5.3
           - v5.4
+          - v6.0
         target:
           - esp32
           - esp32s3
@@ -41,8 +42,20 @@ jobs:
             example: www-image
           - version: v5.4
             example: calibration_helper
+          # IDF 6.0 extended examples (mirrors v5.4 set)
+          - version: v6.0
+            example: screen_diag
+          - version: v6.0
+            example: dragon
+          - version: v6.0
+            example: grayscale_test
+          - version: v6.0
+            example: www-image
+          - version: v6.0
+            example: calibration_helper
 
-    continue-on-error: ${{ matrix.version == 'latest' }}
+    # Allow IDF 6.0 to fail while it is pre-release; remove once stable
+    continue-on-error: ${{ matrix.version == 'latest' || matrix.version == 'v6.0' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +67,7 @@ jobs:
           target: ${{ matrix.target }}
           path: 'examples/${{ matrix.example }}'
 
+  # Arduino-ESP32 IDF 6 support is pending upstream; keep on IDF 5.x for now
   build-arduino:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+      # IDF 6 kconfgen crashes on large sdkconfig.defaults from IDF 5
+      # (upstream bug: choice.selection is None). Use minimal defaults.
+      - name: Use minimal sdkconfig for IDF 6
+        if: startsWith(matrix.version, 'release-v6') || startsWith(matrix.version, 'v6')
+        run: |
+          for f in examples/${{ matrix.example }}/sdkconfig.defaults.*; do
+            [ -f "$f" ] && : > "$f"
+          done
+          printf '%s\n' \
+            "CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y" \
+            "CONFIG_COMPILER_OPTIMIZATION_PERF=y" \
+            "CONFIG_SPIRAM=y" \
+            > examples/${{ matrix.example }}/sdkconfig.defaults
       - uses: 'espressif/esp-idf-ci-action@main'
         with:
           esp_idf_version: ${{ matrix.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           - v5.2
           - v5.3
           - v5.4
-          - v6.0
+          - release-v6.0
         target:
           - esp32
           - esp32s3
@@ -43,19 +43,19 @@ jobs:
           - version: v5.4
             example: calibration_helper
           # IDF 6.0 extended examples (mirrors v5.4 set)
-          - version: v6.0
+          - version: release-v6.0
             example: screen_diag
-          - version: v6.0
+          - version: release-v6.0
             example: dragon
-          - version: v6.0
+          - version: release-v6.0
             example: grayscale_test
-          - version: v6.0
+          - version: release-v6.0
             example: www-image
-          - version: v6.0
+          - version: release-v6.0
             example: calibration_helper
 
-    # Allow IDF 6.0 to fail while it is pre-release; remove once stable
-    continue-on-error: ${{ matrix.version == 'latest' || matrix.version == 'v6.0' }}
+    # Allow IDF 6.0 to fail while it is pre-release; switch to v6.0 once stable
+    continue-on-error: ${{ matrix.version == 'latest' || matrix.version == 'release-v6.0' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ ED*.h
 ES*.h
 examples/private_*/
 *.code-workspace
+.serena/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,11 @@ set(app_sources "src/epdiy.c"
 
 
 # Can also use IDF_VER for the full esp-idf version string but that is harder to parse. i.e. v4.1.1, v5.0-beta1, etc
-if (${IDF_VERSION_MAJOR} GREATER 4)
+if (${IDF_VERSION_MAJOR} GREATER 5)
+    # IDF 6.x: legacy drivers removed, sub-components split out
+    idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/"
+        REQUIRES driver esp_timer esp_adc esp_lcd esp_hal_dma esp_driver_rmt esp_driver_gpio)
+elseif (${IDF_VERSION_MAJOR} GREATER 4)
     idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES driver esp_timer esp_adc esp_lcd)
 else()
     idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES esp_adc_cal esp_timer esp_lcd)

--- a/examples/demo/main/CMakeLists.txt
+++ b/examples/demo/main/CMakeLists.txt
@@ -2,3 +2,8 @@ set(app_sources "main.c")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 idf_component_register(SRCS ${app_sources} REQUIRES epdiy)
+
+# GCC 12+ (IDF 6.0) warns about bidi control chars in generated font headers
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+    target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error=bidi-chars=)
+endif()

--- a/src/board/epd_board_common.c
+++ b/src/board/epd_board_common.c
@@ -1,7 +1,84 @@
-#include "driver/adc.h"
 #include "epd_board.h"
-#include "esp_adc_cal.h"
 #include "esp_log.h"
+
+#include <esp_idf_version.h>
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// IDF 6.x: legacy ADC driver removed, use oneshot driver + calibration
+#include "esp_adc/adc_oneshot.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+
+static adc_oneshot_unit_handle_t adc_handle = NULL;
+static adc_cali_handle_t adc_cali_handle = NULL;
+static const adc_channel_t channel = ADC_CHANNEL_7;
+
+#define NUMBER_OF_SAMPLES 100
+
+void epd_board_temperature_init_v2() {
+    // Initialize ADC oneshot unit
+    adc_oneshot_unit_init_cfg_t unit_cfg = {
+        .unit_id = ADC_UNIT_1,
+    };
+    ESP_ERROR_CHECK(adc_oneshot_new_unit(&unit_cfg, &adc_handle));
+
+    // Configure channel
+    adc_oneshot_chan_cfg_t chan_cfg = {
+        .atten = ADC_ATTEN_DB_6,
+        .bitwidth = ADC_BITWIDTH_12,
+    };
+    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc_handle, channel, &chan_cfg));
+
+    // Initialize calibration
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+    adc_cali_curve_fitting_config_t cali_cfg = {
+        .unit_id = ADC_UNIT_1,
+        .atten = ADC_ATTEN_DB_6,
+        .bitwidth = ADC_BITWIDTH_12,
+    };
+    esp_err_t ret = adc_cali_create_scheme_curve_fitting(&cali_cfg, &adc_cali_handle);
+#elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+    adc_cali_line_fitting_config_t cali_cfg = {
+        .unit_id = ADC_UNIT_1,
+        .atten = ADC_ATTEN_DB_6,
+        .bitwidth = ADC_BITWIDTH_12,
+    };
+    esp_err_t ret = adc_cali_create_scheme_line_fitting(&cali_cfg, &adc_cali_handle);
+#else
+    esp_err_t ret = ESP_ERR_NOT_SUPPORTED;
+#endif
+    if (ret == ESP_OK) {
+        ESP_LOGI("epd_temperature", "ADC calibration scheme initialized");
+    } else {
+        ESP_LOGW("epd_temperature", "ADC calibration not available (err=%d), raw values used", ret);
+    }
+}
+
+float epd_board_ambient_temperature_v2() {
+    int raw = 0;
+    uint32_t value = 0;
+    for (int i = 0; i < NUMBER_OF_SAMPLES; i++) {
+        if (adc_oneshot_read(adc_handle, channel, &raw) == ESP_OK) {
+            value += raw;
+        }
+    }
+    value /= NUMBER_OF_SAMPLES;
+    // voltage in mV
+    int voltage_mv = 0;
+    if (adc_cali_handle != NULL) {
+        adc_cali_raw_to_voltage(adc_cali_handle, (int)value, &voltage_mv);
+    } else {
+        // Fallback: rough estimate without calibration
+        // 12-bit ADC with ~6dB attenuation gives roughly 0-2200mV range
+        voltage_mv = (int)(value * 2200 / 4095);
+    }
+    return ((float)voltage_mv - 500.0f) / 10.0f;
+}
+
+#else
+// IDF 4.x / 5.x: use legacy ADC driver
+#include "driver/adc.h"
+#include "esp_adc_cal.h"
 
 static const adc1_channel_t channel = ADC1_CHANNEL_7;
 static esp_adc_cal_characteristics_t adc_chars;
@@ -32,3 +109,4 @@ float epd_board_ambient_temperature_v2() {
     float voltage = esp_adc_cal_raw_to_voltage(value, &adc_chars);
     return (voltage - 500.0) / 10.0;
 }
+#endif

--- a/src/highlevel.c
+++ b/src/highlevel.c
@@ -31,7 +31,8 @@ EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
 
     int fb_size = epd_width() / 2 * epd_height();
 
-#if !(defined(CONFIG_ESP32_SPIRAM_SUPPORT) || defined(CONFIG_ESP32S3_SPIRAM_SUPPORT))
+#if !(defined(CONFIG_ESP32_SPIRAM_SUPPORT) || defined(CONFIG_ESP32S3_SPIRAM_SUPPORT) \
+      || defined(CONFIG_SPIRAM))
     ESP_LOGW(
         "EPDiy", "Please enable PSRAM for the ESP32 (menuconfig→ Component config→ ESP32-specific)"
     );

--- a/src/highlevel.c
+++ b/src/highlevel.c
@@ -31,8 +31,10 @@ EpdiyHighlevelState epd_hl_init(const EpdWaveform* waveform) {
 
     int fb_size = epd_width() / 2 * epd_height();
 
-#if !(defined(CONFIG_ESP32_SPIRAM_SUPPORT) || defined(CONFIG_ESP32S3_SPIRAM_SUPPORT) \
-      || defined(CONFIG_SPIRAM))
+#if !(                                                                             \
+    defined(CONFIG_ESP32_SPIRAM_SUPPORT) || defined(CONFIG_ESP32S3_SPIRAM_SUPPORT) \
+    || defined(CONFIG_SPIRAM)                                                      \
+)
     ESP_LOGW(
         "EPDiy", "Please enable PSRAM for the ESP32 (menuconfig→ Component config→ ESP32-specific)"
     );

--- a/src/output_i2s/rmt_pulse.c
+++ b/src/output_i2s/rmt_pulse.c
@@ -78,7 +78,7 @@ void rmt_pulse_init(gpio_num_t pin) {
     RMT.conf_ch[RMT_PULSE_CHANNEL].conf0.carrier_out_lv = 0;
     RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.tx_conti_mode = 0;  // loop_en = false
     RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.idle_out_en = 1;
-    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.idle_out_lv = 0;    // idle level low
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.idle_out_lv = 0;  // idle level low
 
     // Connect GPIO to RMT channel
     gpio_set_direction(pin, GPIO_MODE_OUTPUT);

--- a/src/output_i2s/rmt_pulse.c
+++ b/src/output_i2s/rmt_pulse.c
@@ -3,17 +3,15 @@
 
 #ifdef RENDER_METHOD_I2S
 
-#include "driver/rmt.h"
+#include <esp_idf_version.h>
+
 #include "rmt_pulse.h"
 
 #include "soc/rmt_struct.h"
 
 static intr_handle_t gRMT_intr_handle = NULL;
 
-// the RMT channel configuration object
-static rmt_config_t row_rmt_config;
-
-// keep track of wether the current pulse is ongoing
+// keep track of whether the current pulse is ongoing
 volatile bool rmt_tx_done = true;
 
 /**
@@ -26,11 +24,115 @@ static void IRAM_ATTR rmt_interrupt_handler(void* arg) {
 
 // The extern line is declared in esp-idf/components/driver/deprecated/rmt_legacy.c. It has access
 // to RMTMEM through the rmt_private.h header which we can't access outside the sdk. Declare our own
-// extern here to properly use the RMTMEM smybol defined in
+// extern here to properly use the RMTMEM symbol defined in
 // components/soc/[target]/ld/[target].peripherals.ld Also typedef the new rmt_mem_t struct to the
 // old rmt_block_mem_t struct. Same data fields, different names
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// IDF 6.x: rmt_mem_t and rmt_item32_t removed with legacy driver.
+// Define compatible types for direct RMT memory access.
+#include <hal/rmt_types.h>
+#include <hal/rmt_ll.h>
+#include <hal/rmt_periph.h>
+#include <soc/rmt_reg.h>
+typedef struct {
+    union {
+        struct {
+            uint32_t duration0 : 15;
+            uint32_t level0 : 1;
+            uint32_t duration1 : 15;
+            uint32_t level1 : 1;
+        };
+        uint32_t val;
+    };
+} rmt_item32_t;
+#ifndef SOC_RMT_MEM_WORDS_PER_CHANNEL
+#define SOC_RMT_MEM_WORDS_PER_CHANNEL 48
+#endif
+typedef struct {
+    struct {
+        rmt_item32_t data32[SOC_RMT_MEM_WORDS_PER_CHANNEL];
+    } chan[RMT_LL_CHANS_PER_INST];
+} rmt_block_mem_t;
+extern rmt_block_mem_t RMTMEM;
+
+// Channel index used for RMT pulse generation
+#define RMT_PULSE_CHANNEL 1
+#define RMT_MEM_OWNER_TX 1
+
+#include <esp_private/periph_ctrl.h>
+#include <driver/gpio.h>
+#include "esp_rom_gpio.h"
+
+void rmt_pulse_init(gpio_num_t pin) {
+    // Enable RMT peripheral clock via LL (PERIPH_RMT_MODULE removed in IDF 6)
+    PERIPH_RCC_ATOMIC() {
+        rmt_ll_reset_register(0);
+        rmt_ll_enable_bus_clock(0, true);
+    }
+
+    // Configure channel via direct register access (legacy rmt_config() removed in IDF 6)
+    // Set clock divider: 80MHz / 8 = 10MHz -> 0.1us resolution
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf0.div_cnt = 8;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf0.mem_size = 2;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf0.carrier_en = 0;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf0.carrier_out_lv = 0;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.tx_conti_mode = 0;  // loop_en = false
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.idle_out_en = 1;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.idle_out_lv = 0;    // idle level low
+
+    // Connect GPIO to RMT channel
+    gpio_set_direction(pin, GPIO_MODE_OUTPUT);
+    esp_rom_gpio_connect_out_signal(
+        pin, soc_rmt_signals[0].channels[RMT_PULSE_CHANNEL].tx_sig, false, false
+    );
+
+    // Allocate interrupt
+    esp_intr_alloc(
+        ETS_RMT_INTR_SOURCE, ESP_INTR_FLAG_LEVEL3, rmt_interrupt_handler, 0, &gRMT_intr_handle
+    );
+
+    // Enable TX done interrupt for this channel
+    RMT.int_ena.val |= (1 << (RMT_PULSE_CHANNEL * 3));  // TX_END interrupt bit
+}
+
+void rmt_pulse_deinit() {
+    esp_intr_disable(gRMT_intr_handle);
+    esp_intr_free(gRMT_intr_handle);
+}
+
+void IRAM_ATTR pulse_ckv_ticks(uint16_t high_time_ticks, uint16_t low_time_ticks, bool wait) {
+    while (!rmt_tx_done) {
+    };
+    volatile rmt_item32_t* rmt_mem_ptr = &(RMTMEM.chan[RMT_PULSE_CHANNEL].data32[0]);
+    if (high_time_ticks > 0) {
+        rmt_mem_ptr->level0 = 1;
+        rmt_mem_ptr->duration0 = high_time_ticks;
+        rmt_mem_ptr->level1 = 0;
+        rmt_mem_ptr->duration1 = low_time_ticks;
+    } else {
+        rmt_mem_ptr->level0 = 1;
+        rmt_mem_ptr->duration0 = low_time_ticks;
+        rmt_mem_ptr->level1 = 0;
+        rmt_mem_ptr->duration1 = 0;
+    }
+    RMTMEM.chan[RMT_PULSE_CHANNEL].data32[1].val = 0;
+    rmt_tx_done = false;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.mem_rd_rst = 1;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.mem_owner = RMT_MEM_OWNER_TX;
+    RMT.conf_ch[RMT_PULSE_CHANNEL].conf1.tx_start = 1;
+    while (wait && !rmt_tx_done) {
+    };
+}
+
+#else
+// IDF 4.x / 5.x: use legacy RMT driver
+#include "driver/rmt.h"
+
 typedef rmt_mem_t rmt_block_mem_t;
 extern rmt_block_mem_t RMTMEM;
+
+// the RMT channel configuration object
+static rmt_config_t row_rmt_config;
 
 void rmt_pulse_init(gpio_num_t pin) {
     row_rmt_config.rmt_mode = RMT_MODE_TX;
@@ -85,6 +187,7 @@ void IRAM_ATTR pulse_ckv_ticks(uint16_t high_time_ticks, uint16_t low_time_ticks
     while (wait && !rmt_tx_done) {
     };
 }
+#endif
 
 void IRAM_ATTR pulse_ckv_us(uint16_t high_time_us, uint16_t low_time_us, bool wait) {
     pulse_ckv_ticks(10 * high_time_us, 10 * low_time_us, wait);

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -83,6 +83,13 @@ extern const soc_lcd_rgb_signal_desc_t soc_lcd_rgb_signals[LCD_LL_GET(RGB_PANEL_
 
 gpio_hal_context_t hal = { .dev = GPIO_HAL_GET_HW(GPIO_PORT_0) };
 
+// On IDF 5.5+, PERIPH_RCC_ATOMIC() declares __DECLARE_RCC_ATOMIC_ENV as a variable.
+// The workaround define in lcd_driver.h (from #452) must be undone here so it
+// doesn't collide with that declaration.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+#undef __DECLARE_RCC_ATOMIC_ENV
+#endif
+
 #define TAG "epdiy"
 
 // In IDF 5.3.2+, lcd_periph_signals was renamed to lcd_periph_rgb_signals

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -382,7 +382,7 @@ static esp_err_t init_dma_trans_link() {
     // alloc DMA channel and connect to LCD peripheral
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
     // IDF 6.x: config has no direction; allocate TX only (pass NULL for RX)
-    gdma_channel_alloc_config_t dma_chan_config = {0};
+    gdma_channel_alloc_config_t dma_chan_config = { 0 };
     ESP_RETURN_ON_ERROR(
         gdma_new_ahb_channel(&dma_chan_config, &lcd.dma_chan, NULL), TAG, "alloc DMA channel failed"
     );
@@ -402,9 +402,7 @@ static esp_err_t init_dma_trans_link() {
         .max_data_burst_size = 64,
         .access_ext_mem = true,
     };
-    ESP_RETURN_ON_ERROR(
-        gdma_config_transfer(lcd.dma_chan, &trans_cfg), TAG, "dma setup error"
-    );
+    ESP_RETURN_ON_ERROR(gdma_config_transfer(lcd.dma_chan, &trans_cfg), TAG, "dma setup error");
 #else
     gdma_transfer_ability_t ability = {
         .psram_trans_align = 64,
@@ -446,9 +444,7 @@ static esp_err_t init_bus_gpio() {
     for (size_t i = (16 - lcd.config.bus_width); i < 16; i++) {
         gpio_hal_func_sel(&hal, DATA_LINES[i], PIN_FUNC_GPIO);
         gpio_set_direction(DATA_LINES[i], GPIO_MODE_OUTPUT);
-        esp_rom_gpio_connect_out_signal(
-            DATA_LINES[i], LCD_PERIPH_SIG(data_sigs[i]), false, false
-        );
+        esp_rom_gpio_connect_out_signal(DATA_LINES[i], LCD_PERIPH_SIG(data_sigs[i]), false, false);
     }
     gpio_hal_func_sel(&hal, lcd.config.bus.leh, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.leh, GPIO_MODE_OUTPUT);
@@ -457,12 +453,8 @@ static esp_err_t init_bus_gpio() {
     gpio_hal_func_sel(&hal, lcd.config.bus.start_pulse, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.start_pulse, GPIO_MODE_OUTPUT);
 
-    esp_rom_gpio_connect_out_signal(
-        lcd.config.bus.leh, LCD_PERIPH_SIG(hsync_sig), false, false
-    );
-    esp_rom_gpio_connect_out_signal(
-        lcd.config.bus.clock, LCD_PERIPH_SIG(pclk_sig), false, false
-    );
+    esp_rom_gpio_connect_out_signal(lcd.config.bus.leh, LCD_PERIPH_SIG(hsync_sig), false, false);
+    esp_rom_gpio_connect_out_signal(lcd.config.bus.clock, LCD_PERIPH_SIG(pclk_sig), false, false);
     esp_rom_gpio_connect_out_signal(
         lcd.config.bus.start_pulse, LCD_PERIPH_SIG(de_sig), false, false
     );

--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -11,8 +11,6 @@
 #include <assert.h>
 #include <esp_idf_version.h>
 #include <esp_log.h>
-#include <soc/lcd_periph.h>
-#include <soc/rmt_periph.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -21,7 +19,9 @@
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include <driver/rmt_tx.h>
 #include <driver/rmt_types.h>
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
 #include <driver/rmt_types_legacy.h>
+#endif
 #include <esp_private/periph_ctrl.h>
 #include <hal/rmt_types.h>
 #include <soc/clk_tree_defs.h>
@@ -49,8 +49,34 @@
 #include <hal/lcd_hal.h>
 #include <hal/lcd_ll.h>
 #include <hal/rmt_ll.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if __has_include(<rom/cache.h>)
+#include <rom/cache.h>
+#elif __has_include(<esp32s3/rom/cache.h>)
+#include <esp32s3/rom/cache.h>
+#endif
+// Declare LCD peripheral signals from hal/lcd_periph.h without pulling in
+// its transitive I2S dependency. The struct and extern match lcd_periph.h.
+typedef struct {
+    const shared_periph_module_t module;
+    const int irq_id;
+    const int data_sigs[LCD_LL_GET(RGB_BUS_WIDTH)];
+    const int hsync_sig;
+    const int vsync_sig;
+    const int pclk_sig;
+    const int de_sig;
+    const int disp_sig;
+} soc_lcd_rgb_signal_desc_t;
+extern const soc_lcd_rgb_signal_desc_t soc_lcd_rgb_signals[LCD_LL_GET(RGB_PANEL_NUM)];
+#else
 #include <rom/cache.h>
 #include <soc/lcd_periph.h>
+#endif
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <hal/rmt_periph.h>
+#else
+#include <soc/rmt_periph.h>
+#endif
 #include <soc/rmt_struct.h>
 
 #include "hal/gpio_hal.h"
@@ -60,10 +86,13 @@ gpio_hal_context_t hal = { .dev = GPIO_HAL_GET_HW(GPIO_PORT_0) };
 #define TAG "epdiy"
 
 // In IDF 5.3.2+, lcd_periph_signals was renamed to lcd_periph_rgb_signals
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2)
-#define LCD_PERIPH_SIGNALS lcd_periph_signals
+// In IDF 6.x, it became soc_lcd_rgb_signals indexed by panel number
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#define LCD_PERIPH_SIG(member) soc_lcd_rgb_signals[0].member
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2)
+#define LCD_PERIPH_SIG(member) lcd_periph_rgb_signals.panels[0].member
 #else
-#define LCD_PERIPH_SIGNALS lcd_periph_rgb_signals
+#define LCD_PERIPH_SIG(member) lcd_periph_signals.panels[0].member
 #endif
 
 static inline int min(int x, int y) {
@@ -79,17 +108,48 @@ static inline int max(int x, int y) {
 #define LINE_BATCH 1000
 #define BOUNCE_BUF_LINES 4
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// IDF 6.x: legacy RMT enums removed, define channel index directly
+#define RMT_CKV_CHAN 1
+#else
 #define RMT_CKV_CHAN RMT_CHANNEL_1
+#endif
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 // The extern line is declared in esp-idf/components/driver/deprecated/rmt_legacy.c. It has access
 // to RMTMEM through the rmt_private.h header which we can't access outside the sdk. Declare our own
-// extern here to properly use the RMTMEM smybol defined in
+// extern here to properly use the RMTMEM symbol defined in
 // components/soc/[target]/ld/[target].peripherals.ld Also typedef the new rmt_mem_t struct to the
 // old rmt_block_mem_t struct. Same data fields, different names
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// IDF 6.x: rmt_mem_t and rmt_item32_t removed with legacy driver.
+// Define compatible types for direct RMT memory access.
+#include <soc/rmt_reg.h>
+typedef struct {
+    union {
+        struct {
+            uint32_t duration0 : 15;
+            uint32_t level0 : 1;
+            uint32_t duration1 : 15;
+            uint32_t level1 : 1;
+        };
+        uint32_t val;
+    };
+} rmt_item32_t;
+#ifndef SOC_RMT_MEM_WORDS_PER_CHANNEL
+#define SOC_RMT_MEM_WORDS_PER_CHANNEL 48
+#endif
+typedef struct {
+    struct {
+        rmt_item32_t data32[SOC_RMT_MEM_WORDS_PER_CHANNEL];
+    } chan[RMT_LL_CHANS_PER_INST];
+} rmt_block_mem_t;
+extern rmt_block_mem_t RMTMEM;
+#else
 typedef rmt_mem_t rmt_block_mem_t;
 extern rmt_block_mem_t RMTMEM;
 #endif
+#endif  // ESP_IDF_VERSION >= 5.0.0
 
 // spinlock for protecting the critical section at frame start
 static portMUX_TYPE frame_start_spinlock = portMUX_INITIALIZER_UNLOCKED;
@@ -189,10 +249,18 @@ static void ckv_rmt_build_signal() {
  * Configure the RMT peripheral for use as the CKV clock.
  */
 static void init_ckv_rmt() {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    PERIPH_RCC_ATOMIC() {
+        rmt_ll_reset_register(0);
+        rmt_ll_enable_bus_clock(0, true);
+    }
+    rmt_ll_enable_group_clock(&RMT, true);
+#else
     periph_module_reset(PERIPH_RMT_MODULE);
     periph_module_enable(PERIPH_RMT_MODULE);
 
     rmt_ll_enable_periph_clock(&RMT, true);
+#endif
 
     // Divide 80MHz APB Clock by 8 -> .1us resolution delay
     // idf >= 5.0 calculates the clock divider differently
@@ -206,16 +274,22 @@ static void init_ckv_rmt() {
     rmt_ll_tx_set_channel_clock_div(&RMT, RMT_CKV_CHAN, 8);
     rmt_ll_tx_set_mem_blocks(&RMT, RMT_CKV_CHAN, 2);
     rmt_ll_enable_mem_access_nonfifo(&RMT, true);
-    rmt_ll_tx_fix_idle_level(&RMT, RMT_CKV_CHAN, RMT_IDLE_LEVEL_LOW, true);
+    rmt_ll_tx_fix_idle_level(&RMT, RMT_CKV_CHAN, 0, true);
     rmt_ll_tx_enable_carrier_modulation(&RMT, RMT_CKV_CHAN, false);
 
     rmt_ll_tx_enable_loop(&RMT, RMT_CKV_CHAN, true);
 
     gpio_hal_func_sel(&hal, lcd.config.bus.ckv, PIN_FUNC_GPIO);
     gpio_set_direction(lcd.config.bus.ckv, GPIO_MODE_OUTPUT);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp_rom_gpio_connect_out_signal(
+        lcd.config.bus.ckv, soc_rmt_signals[0].channels[RMT_CKV_CHAN].tx_sig, false, 0
+    );
+#else
     esp_rom_gpio_connect_out_signal(
         lcd.config.bus.ckv, rmt_periph_signals.groups[0].channels[RMT_CKV_CHAN].tx_sig, false, 0
     );
+#endif
 
     ckv_rmt_build_signal();
 }
@@ -224,8 +298,15 @@ static void init_ckv_rmt() {
  * Reset the CKV RMT configuration.
  */
 static void deinit_ckv_rmt() {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    PERIPH_RCC_ATOMIC() {
+        rmt_ll_reset_register(0);
+        rmt_ll_enable_bus_clock(0, false);
+    }
+#else
     periph_module_reset(PERIPH_RMT_MODULE);
     periph_module_disable(PERIPH_RMT_MODULE);
+#endif
 
     gpio_reset_pin(lcd.config.bus.ckv);
 }
@@ -299,19 +380,38 @@ static esp_err_t init_dma_trans_link() {
     lcd.dma_nodes[1].next = &lcd.dma_nodes[0];
 
     // alloc DMA channel and connect to LCD peripheral
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    // IDF 6.x: config has no direction; allocate TX only (pass NULL for RX)
+    gdma_channel_alloc_config_t dma_chan_config = {0};
+    ESP_RETURN_ON_ERROR(
+        gdma_new_ahb_channel(&dma_chan_config, &lcd.dma_chan, NULL), TAG, "alloc DMA channel failed"
+    );
+#else
     gdma_channel_alloc_config_t dma_chan_config = {
         .direction = GDMA_CHANNEL_DIRECTION_TX,
     };
     ESP_RETURN_ON_ERROR(
         gdma_new_channel(&dma_chan_config, &lcd.dma_chan), TAG, "alloc DMA channel failed"
     );
+#endif
     gdma_trigger_t trigger = GDMA_MAKE_TRIGGER(GDMA_TRIG_PERIPH_LCD, 0);
     ESP_RETURN_ON_ERROR(gdma_connect(lcd.dma_chan, trigger), TAG, "dma connect error");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    // IDF 6.x: alignment fields replaced by burst size + ext mem flag
+    gdma_transfer_config_t trans_cfg = {
+        .max_data_burst_size = 64,
+        .access_ext_mem = true,
+    };
+    ESP_RETURN_ON_ERROR(
+        gdma_config_transfer(lcd.dma_chan, &trans_cfg), TAG, "dma setup error"
+    );
+#else
     gdma_transfer_ability_t ability = {
         .psram_trans_align = 64,
         .sram_trans_align = 4,
     };
     ESP_RETURN_ON_ERROR(gdma_set_transfer_ability(lcd.dma_chan, &ability), TAG, "dma setup error");
+#endif
 
     gdma_tx_event_callbacks_t cbs = {
         .on_trans_eof = lcd_rgb_panel_eof_handler,
@@ -347,7 +447,7 @@ static esp_err_t init_bus_gpio() {
         gpio_hal_func_sel(&hal, DATA_LINES[i], PIN_FUNC_GPIO);
         gpio_set_direction(DATA_LINES[i], GPIO_MODE_OUTPUT);
         esp_rom_gpio_connect_out_signal(
-            DATA_LINES[i], LCD_PERIPH_SIGNALS.panels[0].data_sigs[i], false, false
+            DATA_LINES[i], LCD_PERIPH_SIG(data_sigs[i]), false, false
         );
     }
     gpio_hal_func_sel(&hal, lcd.config.bus.leh, PIN_FUNC_GPIO);
@@ -358,13 +458,13 @@ static esp_err_t init_bus_gpio() {
     gpio_set_direction(lcd.config.bus.start_pulse, GPIO_MODE_OUTPUT);
 
     esp_rom_gpio_connect_out_signal(
-        lcd.config.bus.leh, LCD_PERIPH_SIGNALS.panels[0].hsync_sig, false, false
+        lcd.config.bus.leh, LCD_PERIPH_SIG(hsync_sig), false, false
     );
     esp_rom_gpio_connect_out_signal(
-        lcd.config.bus.clock, LCD_PERIPH_SIGNALS.panels[0].pclk_sig, false, false
+        lcd.config.bus.clock, LCD_PERIPH_SIG(pclk_sig), false, false
     );
     esp_rom_gpio_connect_out_signal(
-        lcd.config.bus.start_pulse, LCD_PERIPH_SIGNALS.panels[0].de_sig, false, false
+        lcd.config.bus.start_pulse, LCD_PERIPH_SIG(de_sig), false, false
     );
 
     gpio_config_t vsync_gpio_conf = {
@@ -393,13 +493,21 @@ static void deinit_bus_gpio() {
 /**
  * Check if the PSRAM cache is properly configured.
  */
+// Handle Kconfig name changes across IDF versions
+#if defined(CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE)
+#define EPDIY_DATA_CACHE_LINE_SIZE CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE
+#elif defined(CONFIG_DATA_CACHE_LINE_SIZE)
+#define EPDIY_DATA_CACHE_LINE_SIZE CONFIG_DATA_CACHE_LINE_SIZE
+#else
+#define EPDIY_DATA_CACHE_LINE_SIZE 64
+#endif
 static void check_cache_configuration() {
-    if (CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE < 64) {
+    if (EPDIY_DATA_CACHE_LINE_SIZE < 64) {
         ESP_LOGE(
             "epdiy",
             "cache line size is set to %d (< 64B)! This will degrade performance, please update "
             "this option in menuconfig.",
-            CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE
+            EPDIY_DATA_CACHE_LINE_SIZE
         );
         ESP_LOGE(
             "epdiy",
@@ -499,7 +607,16 @@ static esp_err_t init_lcd_peripheral() {
 
     lcd_hal_init(&lcd.hal, 0);
     lcd_ll_enable_clock(lcd.hal.dev, true);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    // IDF 6.x may rename clock source enums
+#if defined(LCD_CLK_SRC_PLL240M)
     lcd_ll_select_clk_src(lcd.hal.dev, LCD_CLK_SRC_PLL240M);
+#else
+    lcd_ll_select_clk_src(lcd.hal.dev, LCD_CLK_SRC_DEFAULT);
+#endif
+#else
+    lcd_ll_select_clk_src(lcd.hal.dev, LCD_CLK_SRC_PLL240M);
+#endif
     ESP_RETURN_ON_ERROR(ret, TAG, "set source clock failed");
 
     // install interrupt service, (LCD peripheral shares the interrupt source with Camera by
@@ -507,7 +624,7 @@ static esp_err_t init_lcd_peripheral() {
     int flags = ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_INTRDISABLED | ESP_INTR_FLAG_SHARED
                 | ESP_INTR_FLAG_LOWMED;
 
-    int source = LCD_PERIPH_SIGNALS.panels[0].irq_id;
+    int source = LCD_PERIPH_SIG(irq_id);
     uint32_t status = (uint32_t)lcd_ll_get_interrupt_status_reg(lcd.hal.dev);
     ret = esp_intr_alloc_intrstatus(
         source, flags, status, LCD_LL_EVENT_VSYNC_END, lcd_isr_vsync, NULL, &lcd.vsync_intr
@@ -551,8 +668,15 @@ static esp_err_t init_lcd_peripheral() {
     // send next frame automatically in stream mode
     lcd_ll_enable_auto_next_frame(lcd.hal.dev, false);
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    PERIPH_RCC_ATOMIC() {
+        lcd_ll_enable_interrupt(lcd.hal.dev, LCD_LL_EVENT_VSYNC_END, true);
+        lcd_ll_enable_interrupt(lcd.hal.dev, LCD_LL_EVENT_TRANS_DONE, true);
+    }
+#else
     lcd_ll_enable_interrupt(lcd.hal.dev, LCD_LL_EVENT_VSYNC_END, true);
     lcd_ll_enable_interrupt(lcd.hal.dev, LCD_LL_EVENT_TRANS_DONE, true);
+#endif
 
     // enable intr
     esp_intr_enable(lcd.vsync_intr);

--- a/src/output_lcd/render_lcd.c
+++ b/src/output_lcd/render_lcd.c
@@ -5,8 +5,18 @@
 
 #ifdef RENDER_METHOD_LCD
 
+#include <esp_idf_version.h>
 #include <esp_log.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// IDF 6.x: rom/cache.h may be relocated; try target-specific path
+#if __has_include(<rom/cache.h>)
 #include <rom/cache.h>
+#elif __has_include(<esp32s3/rom/cache.h>)
+#include <esp32s3/rom/cache.h>
+#endif
+#else
+#include <rom/cache.h>
+#endif
 
 #include "../epd_internals.h"
 #include "../output_common/line_queue.h"


### PR DESCRIPTION
## Summary

Adds ESP-IDF 6.0 support while maintaining full backward compatibility with IDF 5.x (tested against 5.5). All changes use `#if ESP_IDF_VERSION` guards so both major versions compile cleanly for both ESP32 and ESP32-S3 targets.

Closes #450

## Detailed changes

### Build system (`CMakeLists.txt`)
- Added IDF 6.x branch for component registration: IDF 6 splits legacy `driver` into sub-components (`esp_hal_dma`, `esp_driver_rmt`, `esp_driver_gpio`), so these are now listed as explicit REQUIRES for `IDF_VERSION_MAJOR > 5`
- Existing IDF 4.x and 5.x branches are untouched

### LCD driver — ESP32-S3 (`src/output_lcd/lcd_driver.c`)
- **LCD peripheral signals**: struct renamed from `lcd_periph_signals.panels[0].member` / `lcd_periph_rgb_signals.panels[0].member` to array `soc_lcd_rgb_signals[0].member` in IDF 6. Replaced `LCD_PERIPH_SIGNALS` macro with `LCD_PERIPH_SIG(member)` to abstract the access pattern across all three naming conventions
- **LCD signal struct**: forward-declared `soc_lcd_rgb_signal_desc_t` and extern `soc_lcd_rgb_signals` directly instead of including `hal/lcd_periph.h`, which in IDF 6 transitively pulls in `hal/i2s_ll.h` causing conflicts
- **GDMA API**: `gdma_new_channel()` replaced by `gdma_new_ahb_channel()` in IDF 6 — takes 3 args (config, tx_chan, rx_chan) and `gdma_channel_alloc_config_t` no longer has a `direction` member
- **RMT peripheral clock**: `periph_module_enable(PERIPH_RMT_MODULE)` removed in IDF 6 (`PERIPH_RMT_MODULE` no longer exists in `shared_periph_module_t`). Replaced with `rmt_ll_enable_bus_clock()` + `rmt_ll_reset_register()` inside `PERIPH_RCC_ATOMIC()` blocks
- **RMT LL rename**: `rmt_ll_enable_periph_clock()` renamed to `rmt_ll_enable_group_clock()` in IDF 6
- **RMT types**: `rmt_item32_t` removed with legacy RMT driver in IDF 6 — defined locally with identical layout
- **RMT signals struct**: `rmt_periph_signals.groups[0]` renamed to array `soc_rmt_signals[0]` in IDF 6
- **RMT channel count**: `SOC_RMT_CHANNELS_PER_GROUP` removed — replaced with `RMT_LL_CHANS_PER_INST` from `hal/rmt_ll.h`
- **RMT periph header**: moved from `soc/rmt_periph.h` to `hal/rmt_periph.h` in IDF 6
- **LCD LL interrupt macro**: IDF 5.5+ added a wrapper macro around `lcd_ll_enable_interrupt()` that references `__DECLARE_RCC_ATOMIC_ENV`, requiring the caller to be inside a `PERIPH_RCC_ATOMIC()` block. Guard lowered to `>= 5.5.0` (not just 6.0)

### RMT pulse driver — ESP32 (`src/output_i2s/rmt_pulse.c`)
- **Legacy RMT driver removed**: `driver/rmt.h` (`rmt_config()`, `rmt_set_tx_intr_en()`, `rmt_config_t`) completely removed in IDF 6. Replaced init with direct register writes matching what `rmt_config()` did internally — the actual pulse generation already used direct RMTMEM access
- **RMT types**: locally defined `rmt_item32_t` and `rmt_block_mem_t` for IDF 6 (same approach as lcd_driver.c)
- **Peripheral clock**: same `PERIPH_RCC_ATOMIC()` + LL function pattern as lcd_driver.c
- **GPIO routing**: `gpio_matrix_out()` replaced with `esp_rom_gpio_connect_out_signal()` via `esp_rom_gpio.h`

### I2S data bus — ESP32 (`src/output_i2s/i2s_data_bus.c`)
- **Peripheral clock**: `periph_module_enable(PERIPH_I2S1_MODULE)` removed in IDF 6 — replaced with `i2s_ll_enable_bus_clock(1, true)` + `i2s_ll_reset_register(1)` inside `PERIPH_RCC_ATOMIC()`. Same for disable in `i2s_bus_deinit()`
- **GPIO signal macros**: `I2S1O_DATA_OUT0_IDX` / `I2S1O_WS_OUT_IDX` lost their transitive include path in IDF 6 — added explicit `#include "soc/gpio_sig_map.h"`
- **GPIO routing**: `gpio_matrix_out()` replaced with `esp_rom_gpio_connect_out_signal()` for IDF 6

### ADC temperature sensing (`src/board/epd_board_common.c`)
- **Legacy ADC API removed**: `adc1_get_raw()`, `esp_adc_cal_characterize()`, `esp_adc_cal_raw_to_voltage()` all removed in IDF 6
- Reimplemented `epd_board_temperature_init_v2()` and `epd_board_ambient_temperature_v2()` using the oneshot ADC driver (`adc_oneshot_new_unit`, `adc_oneshot_config_channel`, `adc_oneshot_read`) + new calibration API (`adc_cali_create_scheme_line_fitting`, `adc_cali_raw_to_voltage`)

### Cache header path (`src/output_lcd/render_lcd.c`)
- `rom/cache.h` may be relocated in IDF 6 — added `__has_include` fallback to `esp32s3/rom/cache.h`

### SPIRAM config (`src/highlevel.c`)
- IDF 6 unifies `CONFIG_ESP32_SPIRAM_SUPPORT` / `CONFIG_ESP32S3_SPIRAM_SUPPORT` under `CONFIG_SPIRAM` — added it as an additional check

### Demo build (`examples/demo/main/CMakeLists.txt`)
- GCC 15 (shipped with IDF 6) treats `-Wbidi-chars=` as an error for Unicode bidirectional control characters in the generated font header files. Added `-Wno-error=bidi-chars=` compile option

### CI (`.github/workflows/main.yml`)
- Added `release-v6.0` to the build matrix for both ESP32 and ESP32-S3 (switch to `v6.0` once the stable Docker tag exists)
- Added IDF 6 extended examples (mirrors the v5.4 set)
- Set `continue-on-error: true` for IDF 6 while it is pre-release
- IDF 6 kconfgen crashes on large sdkconfig.defaults from IDF 5 (upstream bug: `choice.selection` is None). CI uses minimal sdkconfig.defaults for IDF 6 builds as a workaround
- Added comment noting Arduino-ESP32 IDF 6 support is pending upstream

## CI results

| Target | IDF 5.2 | IDF 5.3 | IDF 5.4 | IDF 6.0 |
|--------|---------|---------|---------|---------|
| ESP32-S3 demo | PASS | PASS | PASS | PASS |
| ESP32 demo | PASS | PASS | PASS | PASS |
| screen_diag | — | — | PASS | PASS |
| dragon | — | — | PASS | PASS |
| grayscale_test | — | — | PASS | PASS |
| calibration_helper | — | — | PASS | PASS |
| www-image | — | — | PASS | FAIL (*) |
| Arduino weather | PASS (v5.3.2) | | | |

(*) `www-image` fails on IDF 6 due to GCC 15 warnings-as-errors in the third-party `bitbank2/jpegdec` managed component (`-Werror=pointer-to-int-cast`, `-Werror=shift-negative-value`), not epdiy code. Requires an upstream fix to jpegdec.

## Test plan

- [x] CI passes for IDF 5.2, 5.3, 5.4 (all green)
- [x] CI passes for IDF 6.0 ESP32 and ESP32-S3 demo builds
- [x] CI passes for IDF 6.0 extended examples (except www-image — third-party dependency)
- [ ] Verify demo runs correctly on physical ESP32-S3 hardware with IDF 6.0
- [ ] Verify demo runs correctly on physical ESP32 hardware with IDF 6.0
- [ ] Once IDF 6.0 reaches stable release, switch `release-v6.0` to `v6.0` and remove `continue-on-error`