### PR TITLE
fix: remove duplicate check_cache_configuration() call in epd_lcd_init

### DIFF
--- a/src/output_lcd/lcd_driver.c
+++ b/src/output_lcd/lcd_driver.c
@@ -581,8 +581,6 @@ void epd_lcd_init(const LcdEpdConfig_t* config, int display_width, int display_h
     esp_err_t ret = ESP_OK;
     assign_lcd_parameters_from_config(config, display_width, display_height);
 
-    check_cache_configuration();
-
     ret = allocate_lcd_buffers();
     ESP_GOTO_ON_ERROR(ret, err, TAG, "lcd buffer allocation failed");
 


### PR DESCRIPTION
## Problem

`check_cache_configuration()` is called twice during LCD initialization:
1. Inside `assign_lcd_parameters_from_config()` (line 450)
2. Again in `epd_lcd_init()` (line 584), right after calling `assign_lcd_parameters_from_config()`

Each call halves the pixel clock when `CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE < 64`. On Arduino platforms where this value is hardcoded to 32, this causes the pixel clock to be reduced twice (e.g., 20 MHz → 10 MHz → 5 MHz) instead of once (20 MHz → 10 MHz).

## Fix

Remove the redundant `check_cache_configuration()` call in `epd_lcd_init()`, since it is already called inside `assign_lcd_parameters_from_config()`.