### PR TITLE
Migrate ADC to new 5.x driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,27 +35,27 @@ set(app_sources "src/epdiy.c"
 )
 
 
-# Can also use IDF_VER for the full esp-idf version string but that is harder to parse. i.e. v4.1.1, v5.0-beta1, etc
-if (${IDF_VERSION_MAJOR} GREATER 4)
-    set(epdiy_requires driver esp_timer esp_adc esp_lcd)
-    if (${IDF_VERSION_MAJOR} GREATER 5 OR (${IDF_VERSION_MAJOR} EQUAL 5 AND ${IDF_VERSION_MINOR} GREATER 2))
-        list(APPEND epdiy_requires esp_driver_i2c)
-    endif()
-
-    set(epdiy_private_requires hal soc esp_hw_support esp_rom)
-    if(DEFINED IDF_VERSION_MAJOR AND IDF_VERSION_MAJOR GREATER_EQUAL 6)
-        list(APPEND epdiy_private_requires esp_hal_rmt)
-    endif()
-
-    idf_component_register(
-        SRCS ${app_sources}
-        INCLUDE_DIRS "src/"
-        REQUIRES ${epdiy_requires}
-        PRIV_REQUIRES ${epdiy_private_requires}
-    )
-else()
-    idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES esp_adc_cal esp_timer esp_lcd)
+# Can also use IDF_VER for the full esp-idf version string but that is harder to parse. i.e. v5.0-beta1, etc
+if (${IDF_VERSION_MAJOR} LESS 5)
+    message(FATAL_ERROR "epdiy requires ESP-IDF 5.x or newer")
 endif()
+
+set(epdiy_requires driver esp_timer esp_adc esp_lcd)
+if (${IDF_VERSION_MAJOR} GREATER 5 OR (${IDF_VERSION_MAJOR} EQUAL 5 AND ${IDF_VERSION_MINOR} GREATER 2))
+    list(APPEND epdiy_requires esp_driver_i2c)
+endif()
+
+set(epdiy_private_requires hal soc esp_hw_support esp_rom)
+if(DEFINED IDF_VERSION_MAJOR AND IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    list(APPEND epdiy_private_requires esp_hal_rmt)
+endif()
+
+idf_component_register(
+    SRCS ${app_sources}
+    INCLUDE_DIRS "src/"
+    REQUIRES ${epdiy_requires}
+    PRIV_REQUIRES ${epdiy_private_requires}
+)
 
 # formatting specifiers maybe incompatible between idf versions because of different int definitions
 component_compile_options(-Wno-error=format= -Wno-format)

--- a/src/board/epd_board_common.c
+++ b/src/board/epd_board_common.c
@@ -1,34 +1,81 @@
-#include "driver/adc.h"
 #include "epd_board.h"
-#include "esp_adc_cal.h"
 #include "esp_log.h"
 
-static const adc1_channel_t channel = ADC1_CHANNEL_7;
-static esp_adc_cal_characteristics_t adc_chars;
+#include "esp_adc/adc_oneshot.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+
+static adc_oneshot_unit_handle_t adc_handle = NULL;
+static adc_cali_handle_t adc_cali_handle = NULL;
+static const adc_channel_t channel = ADC_CHANNEL_7;
 
 #define NUMBER_OF_SAMPLES 100
 
 void epd_board_temperature_init_v2() {
-    esp_adc_cal_value_t val_type
-        = esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_6, ADC_WIDTH_BIT_12, 1100, &adc_chars);
-    if (val_type == ESP_ADC_CAL_VAL_EFUSE_TP) {
-        ESP_LOGI("epd_temperature", "Characterized using Two Point Value\n");
-    } else if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
-        ESP_LOGI("esp_temperature", "Characterized using eFuse Vref\n");
+    adc_oneshot_unit_init_cfg_t unit_cfg = {
+        .unit_id = ADC_UNIT_1,
+    };
+    ESP_ERROR_CHECK(adc_oneshot_new_unit(&unit_cfg, &adc_handle));
+
+    adc_oneshot_chan_cfg_t chan_cfg = {
+        .atten = ADC_ATTEN_DB_6,
+        .bitwidth = ADC_BITWIDTH_12,
+    };
+    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc_handle, channel, &chan_cfg));
+
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+    adc_cali_curve_fitting_config_t cali_cfg = {
+        .unit_id = ADC_UNIT_1,
+        .atten = ADC_ATTEN_DB_6,
+        .bitwidth = ADC_BITWIDTH_12,
+    };
+    esp_err_t ret = adc_cali_create_scheme_curve_fitting(&cali_cfg, &adc_cali_handle);
+#elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+    adc_cali_line_fitting_config_t cali_cfg = {
+        .unit_id = ADC_UNIT_1,
+        .atten = ADC_ATTEN_DB_6,
+        .bitwidth = ADC_BITWIDTH_12,
+    };
+    esp_err_t ret = adc_cali_create_scheme_line_fitting(&cali_cfg, &adc_cali_handle);
+#else
+    esp_err_t ret = ESP_ERR_NOT_SUPPORTED;
+#endif
+    if (ret == ESP_OK) {
+        ESP_LOGI("epd_temperature", "ADC calibration scheme initialized");
     } else {
-        ESP_LOGI("esp_temperature", "Characterized using Default Vref\n");
+        ESP_LOGW("epd_temperature", "ADC calibration not available (err=%d), raw values used", ret);
     }
-    adc1_config_width(ADC_WIDTH_BIT_12);
-    adc1_config_channel_atten(channel, ADC_ATTEN_DB_6);
 }
 
 float epd_board_ambient_temperature_v2() {
+    int raw = 0;
     uint32_t value = 0;
     for (int i = 0; i < NUMBER_OF_SAMPLES; i++) {
-        value += adc1_get_raw(channel);
+        if (adc_oneshot_read(adc_handle, channel, &raw) == ESP_OK) {
+            value += raw;
+        }
     }
     value /= NUMBER_OF_SAMPLES;
-    // voltage in mV
-    float voltage = esp_adc_cal_raw_to_voltage(value, &adc_chars);
-    return (voltage - 500.0) / 10.0;
+    int voltage_mv = 0;
+    if (adc_cali_handle != NULL) {
+        adc_cali_raw_to_voltage(adc_cali_handle, (int)value, &voltage_mv);
+    } else {
+        voltage_mv = (int)(value * 2200 / 4095);
+    }
+    return ((float)voltage_mv - 500.0f) / 10.0f;
+}
+
+void epd_board_temperature_deinit_v2() {
+    if (adc_handle != NULL) {
+        ESP_ERROR_CHECK(adc_oneshot_del_unit(adc_handle));
+        adc_handle = NULL;
+    }
+    if (adc_cali_handle != NULL) {
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+        ESP_ERROR_CHECK(adc_cali_delete_scheme_curve_fitting(adc_cali_handle));
+#elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+        ESP_ERROR_CHECK(adc_cali_delete_scheme_line_fitting(adc_cali_handle));
+#endif
+        adc_cali_handle = NULL;
+    }
 }

--- a/src/board/epd_board_common.c
+++ b/src/board/epd_board_common.c
@@ -50,15 +50,22 @@ void epd_board_temperature_init_v2() {
 float epd_board_ambient_temperature_v2() {
     int raw = 0;
     uint32_t value = 0;
+    int successful_samples = 0;
     for (int i = 0; i < NUMBER_OF_SAMPLES; i++) {
         if (adc_oneshot_read(adc_handle, channel, &raw) == ESP_OK) {
             value += raw;
+            successful_samples++;
         }
     }
-    value /= NUMBER_OF_SAMPLES;
+    if (successful_samples == 0) {
+        return 20.0f;
+    }
+    value /= successful_samples;
     int voltage_mv = 0;
     if (adc_cali_handle != NULL) {
-        adc_cali_raw_to_voltage(adc_cali_handle, (int)value, &voltage_mv);
+        if (adc_cali_raw_to_voltage(adc_cali_handle, (int)value, &voltage_mv) != ESP_OK) {
+            return 20.0f;
+        }
     } else {
         voltage_mv = (int)(value * 2200 / 4095);
     }

--- a/src/board/epd_board_common.h
+++ b/src/board/epd_board_common.h
@@ -6,3 +6,4 @@
 
 void epd_board_temperature_init_v2();
 float epd_board_ambient_temperature_v2();
+void epd_board_temperature_deinit_v2();

--- a/src/board/epd_board_v2_v3.c
+++ b/src/board/epd_board_v2_v3.c
@@ -159,12 +159,15 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     i2s_gpio_detach(&i2s_config);
-    // END POWEROFF
+}
+
+static void epd_board_deinit() {
+    epd_board_temperature_deinit_v2();
 }
 
 const EpdBoardDefinition epd_board_v2_v3 = {
     .init = epd_board_init,
-    .deinit = NULL,
+    .deinit = epd_board_deinit,
     .set_ctrl = epd_board_set_ctrl,
     .poweron = epd_board_poweron,
     .poweroff = epd_board_poweroff,

--- a/src/board/epd_board_v2_v3.c
+++ b/src/board/epd_board_v2_v3.c
@@ -158,12 +158,15 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     i2s_gpio_detach(&i2s_config);
-    // END POWEROFF
+}
+
+static void epd_board_deinit() {
+    epd_board_temperature_deinit_v2();
 }
 
 const EpdBoardDefinition epd_board_v2_v3 = {
     .init = epd_board_init,
-    .deinit = NULL,
+    .deinit = epd_board_deinit,
     .set_ctrl = epd_board_set_ctrl,
     .poweron = epd_board_poweron,
     .poweroff = epd_board_poweroff,

--- a/src/board/epd_board_v4.c
+++ b/src/board/epd_board_v4.c
@@ -181,12 +181,15 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     i2s_gpio_detach(&i2s_config);
-    // END POWEROFF
+}
+
+static void epd_board_deinit() {
+    epd_board_temperature_deinit_v2();
 }
 
 const EpdBoardDefinition epd_board_v4 = {
     .init = epd_board_init,
-    .deinit = NULL,
+    .deinit = epd_board_deinit,
     .set_ctrl = epd_board_set_ctrl,
     .poweron = epd_board_poweron,
     .poweroff = epd_board_poweroff,

--- a/src/board/epd_board_v4.c
+++ b/src/board/epd_board_v4.c
@@ -180,12 +180,15 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     i2s_gpio_detach(&i2s_config);
-    // END POWEROFF
+}
+
+static void epd_board_deinit() {
+    epd_board_temperature_deinit_v2();
 }
 
 const EpdBoardDefinition epd_board_v4 = {
     .init = epd_board_init,
-    .deinit = NULL,
+    .deinit = epd_board_deinit,
     .set_ctrl = epd_board_set_ctrl,
     .poweron = epd_board_poweron,
     .poweroff = epd_board_poweroff,

--- a/src/board/epd_board_v5.c
+++ b/src/board/epd_board_v5.c
@@ -183,12 +183,15 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     i2s_gpio_detach(&i2s_config);
-    // END POWEROFF
+}
+
+static void epd_board_deinit() {
+    epd_board_temperature_deinit_v2();
 }
 
 const EpdBoardDefinition epd_board_v5 = {
     .init = epd_board_init,
-    .deinit = NULL,
+    .deinit = epd_board_deinit,
     .set_ctrl = epd_board_set_ctrl,
     .poweron = epd_board_poweron,
     .poweroff = epd_board_poweroff,

--- a/src/board/epd_board_v5.c
+++ b/src/board/epd_board_v5.c
@@ -182,12 +182,15 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     i2s_gpio_detach(&i2s_config);
-    // END POWEROFF
+}
+
+static void epd_board_deinit() {
+    epd_board_temperature_deinit_v2();
 }
 
 const EpdBoardDefinition epd_board_v5 = {
     .init = epd_board_init,
-    .deinit = NULL,
+    .deinit = epd_board_deinit,
     .set_ctrl = epd_board_set_ctrl,
     .poweron = epd_board_poweron,
     .poweroff = epd_board_poweroff,


### PR DESCRIPTION
Since IDF 4.x support is dropped, we can migrate to the new ADC driver. 
This was extracted from https://github.com/vroland/epdiy/pull/463 by @Bwooce.