### PR TITLE
Migrate epdiy board I2C init to the new ESP-IDF driver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
             example: www-image
           - version: v5.4
             example: calibration_helper
+          - version: v5.4
+            example: test
 
     continue-on-error: ${{ matrix.version == 'latest' }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,11 @@ set(app_sources "src/epdiy.c"
 
 # Can also use IDF_VER for the full esp-idf version string but that is harder to parse. i.e. v4.1.1, v5.0-beta1, etc
 if (${IDF_VERSION_MAJOR} GREATER 4)
-    idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES esp_driver_i2c driver esp_timer esp_adc esp_lcd)
+    set(epdiy_requires driver esp_timer esp_adc esp_lcd)
+    if (${IDF_VERSION_MAJOR} GREATER 5 OR (${IDF_VERSION_MAJOR} EQUAL 5 AND ${IDF_VERSION_MINOR} GREATER 2))
+        list(APPEND epdiy_requires esp_driver_i2c)
+    endif()
+    idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES ${epdiy_requires})
 else()
     idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES esp_adc_cal esp_timer esp_lcd)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(app_sources "src/epdiy.c"
                 "src/highlevel.c"
                 "src/board/tps65185.c"
                 "src/board/pca9555.c"
+                "src/board/epd_board_i2c.c"
                 "src/board/epd_board.c"
                 "src/board/epd_board_common.c"
                 "src/board/epd_board_lilygo_t5_47.c"
@@ -35,7 +36,7 @@ set(app_sources "src/epdiy.c"
 
 # Can also use IDF_VER for the full esp-idf version string but that is harder to parse. i.e. v4.1.1, v5.0-beta1, etc
 if (${IDF_VERSION_MAJOR} GREATER 4)
-    idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES driver esp_timer esp_adc esp_lcd)
+    idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES esp_driver_i2c driver esp_timer esp_adc esp_lcd)
 else()
     idf_component_register(SRCS ${app_sources} INCLUDE_DIRS "src/" REQUIRES esp_adc_cal esp_timer esp_lcd)
 endif()

--- a/README.md
+++ b/README.md
@@ -139,22 +139,27 @@ In Arduino it works like this.
 
  `esp_deep_sleep_start();`
 
-### I2C Bus Sharing (Arduino)
+### I2C Bus Sharing
 
-When using epdiy with Arduino on boards like the T5 S3 E-Paper Pro, you may need to share the I2C bus between epdiy and other peripherals (touch controller, RTC, battery gauge, etc.).
+EPDIY now uses the ESP-IDF master bus/device I2C driver on IDF 5.x and newer.
 
-Epdiy's board initialization will detect if the I2C driver is already installed (e.g., by Arduino's `Wire.begin()`) and reuse the existing driver instead of failing. This allows you to:
+Existing programs can keep calling `epd_init(...)` and EPDIY will create and own the board's default I2C bus.
 
-1. Call `Wire.begin(SDA, SCL)` before `epd_init()` to initialize the I2C bus
-2. Use `Wire` for other I2C devices (GT911 touch, PCF8563 RTC, BQ27220 fuel gauge)
-3. Protect shared I2C access with a mutex if accessing from multiple tasks
+If your application already owns an ESP-IDF I2C master bus, pass it in during initialization:
 
-Example initialization order for T5 S3 E-Paper Pro:
-```cpp
-Wire.begin(39, 40);  // Initialize I2C first (SDA=39, SCL=40)
-epd_init(&epd_board_v7, &ED047TC1, EPD_LUT_64K);  // epdiy reuses I2C driver
-// Now both epdiy and Wire can coexist on the same I2C bus
+```c
+i2c_master_bus_handle_t bus = ...;
+EpdI2cConfig i2c_config = {
+    .bus_handle = bus,
+};
+EpdInitConfig init_config = {
+    .i2c = &i2c_config,
+};
+
+epd_init_with_config(&epd_board_v7, &ED047TC1, EPD_LUT_64K, &init_config);
 ```
+
+When a bus handle is provided, EPDIY will attach its TPS65185/PCA9555 devices to that bus and leave bus ownership to the caller.
 
 More on E-Paper Displays
 ------------------------

--- a/examples/demo/main/main.c
+++ b/examples/demo/main/main.c
@@ -38,7 +38,7 @@
 EpdiyHighlevelState hl;
 
 void idf_setup() {
-    epd_init(&DEMO_BOARD, &ED078KC1, EPD_LUT_64K);
+    epd_init(&DEMO_BOARD, &ED097TC2, EPD_LUT_64K);
     // Set VCOM for boards that allow to set this in software (in mV).
     // This will print an error if unsupported. In this case,
     // set VCOM using the hardware potentiometer and delete this line.

--- a/examples/demo/main/main.c
+++ b/examples/demo/main/main.c
@@ -38,7 +38,7 @@
 EpdiyHighlevelState hl;
 
 void idf_setup() {
-    epd_init(&DEMO_BOARD, &ED097TC2, EPD_LUT_64K);
+    epd_init(&DEMO_BOARD, &ED078KC1, EPD_LUT_64K);
     // Set VCOM for boards that allow to set this in software (in mV).
     // This will print an error if unsupported. In this case,
     // set VCOM using the hardware potentiometer and delete this line.

--- a/src/board/epd_board_i2c.c
+++ b/src/board/epd_board_i2c.c
@@ -1,0 +1,96 @@
+#include "epd_board_i2c.h"
+
+#include "pca9555.h"
+#include "epdiy.h"
+
+#include <esp_log.h>
+
+static const uint32_t GLITCH_IGNORE_COUNT = 7;
+static i2c_master_dev_handle_t current_tps;
+
+const EpdInitConfig* epd_get_init_config();
+
+static esp_err_t epd_board_i2c_add_device(
+    i2c_master_bus_handle_t bus,
+    uint16_t address,
+    uint32_t bus_speed_hz,
+    i2c_master_dev_handle_t* out_dev
+) {
+    i2c_device_config_t device_config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = address,
+        .scl_speed_hz = bus_speed_hz,
+    };
+    return i2c_master_bus_add_device(bus, &device_config, out_dev);
+}
+
+esp_err_t epd_board_i2c_init(
+    epd_board_i2c_context_t* ctx,
+    const epd_board_i2c_bus_config_t* defaults,
+    bool need_tps,
+    bool need_pca
+) {
+    *ctx = (epd_board_i2c_context_t){ 0 };
+
+    const EpdInitConfig* init_config = epd_get_init_config();
+    if (init_config && init_config->i2c && init_config->i2c->bus_handle) {
+        ctx->bus = init_config->i2c->bus_handle;
+        ctx->owns_bus = false;
+    } else {
+        i2c_master_bus_config_t bus_config = {
+            .i2c_port = defaults->port,
+            .sda_io_num = defaults->sda_io_num,
+            .scl_io_num = defaults->scl_io_num,
+            .clk_source = I2C_CLK_SRC_DEFAULT,
+            .glitch_ignore_cnt = GLITCH_IGNORE_COUNT,
+            .flags.enable_internal_pullup = true,
+        };
+        esp_err_t err = i2c_new_master_bus(&bus_config, &ctx->bus);
+        if (err != ESP_OK) {
+            ESP_LOGE("epdiy", "failed to create I2C bus");
+            return err;
+        }
+        ctx->owns_bus = true;
+    }
+
+    if (need_tps) {
+        esp_err_t err = epd_board_i2c_add_device(ctx->bus, 0x68, defaults->bus_speed_hz, &ctx->tps);
+        if (err != ESP_OK) {
+            epd_board_i2c_deinit(ctx);
+            return err;
+        }
+        current_tps = ctx->tps;
+    }
+
+    if (need_pca) {
+        esp_err_t err = epd_board_i2c_add_device(
+            ctx->bus, EPDIY_PCA9555_ADDR, defaults->bus_speed_hz, &ctx->pca
+        );
+        if (err != ESP_OK) {
+            epd_board_i2c_deinit(ctx);
+            return err;
+        }
+    }
+
+    return ESP_OK;
+}
+
+void epd_board_i2c_deinit(epd_board_i2c_context_t* ctx) {
+    if (ctx->pca) {
+        i2c_master_bus_rm_device(ctx->pca);
+    }
+    if (ctx->tps) {
+        if (current_tps == ctx->tps) {
+            current_tps = NULL;
+        }
+        i2c_master_bus_rm_device(ctx->tps);
+    }
+    if (ctx->owns_bus && ctx->bus) {
+        i2c_del_master_bus(ctx->bus);
+    }
+    *ctx = (epd_board_i2c_context_t){ 0 };
+}
+
+i2c_master_dev_handle_t epd_board_i2c_current_tps() {
+    return current_tps;
+}

--- a/src/board/epd_board_i2c.c
+++ b/src/board/epd_board_i2c.c
@@ -8,8 +8,6 @@
 static const uint32_t GLITCH_IGNORE_COUNT = 7;
 static i2c_master_dev_handle_t current_tps;
 
-const EpdInitConfig* epd_get_init_config();
-
 static esp_err_t epd_board_i2c_add_device(
     i2c_master_bus_handle_t bus,
     uint16_t address,
@@ -27,12 +25,12 @@ static esp_err_t epd_board_i2c_add_device(
 esp_err_t epd_board_i2c_init(
     epd_board_i2c_context_t* ctx,
     const epd_board_i2c_bus_config_t* defaults,
+    const EpdInitConfig* init_config,
     bool need_tps,
     bool need_pca
 ) {
     *ctx = (epd_board_i2c_context_t){ 0 };
 
-    const EpdInitConfig* init_config = epd_get_init_config();
     if (init_config && init_config->i2c && init_config->i2c->bus_handle) {
         ctx->bus = init_config->i2c->bus_handle;
         ctx->owns_bus = false;

--- a/src/board/epd_board_i2c.h
+++ b/src/board/epd_board_i2c.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <driver/gpio.h>
+#include <driver/i2c_master.h>
+#include <esp_err.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    i2c_port_num_t port;
+    gpio_num_t sda_io_num;
+    gpio_num_t scl_io_num;
+    uint32_t bus_speed_hz;
+} epd_board_i2c_bus_config_t;
+
+typedef struct {
+    i2c_master_bus_handle_t bus;
+    i2c_master_dev_handle_t tps;
+    i2c_master_dev_handle_t pca;
+    bool owns_bus;
+} epd_board_i2c_context_t;
+
+esp_err_t epd_board_i2c_init(
+    epd_board_i2c_context_t* ctx,
+    const epd_board_i2c_bus_config_t* defaults,
+    bool need_tps,
+    bool need_pca
+);
+void epd_board_i2c_deinit(epd_board_i2c_context_t* ctx);
+i2c_master_dev_handle_t epd_board_i2c_current_tps();

--- a/src/board/epd_board_i2c.h
+++ b/src/board/epd_board_i2c.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "epd_init_config.h"
+
 typedef struct {
     i2c_port_num_t port;
     gpio_num_t sda_io_num;
@@ -23,6 +25,7 @@ typedef struct {
 esp_err_t epd_board_i2c_init(
     epd_board_i2c_context_t* ctx,
     const epd_board_i2c_bus_config_t* defaults,
+    const EpdInitConfig* init_config,
     bool need_tps,
     bool need_pca
 );

--- a/src/board/epd_board_lilygo_t5_47.c
+++ b/src/board/epd_board_lilygo_t5_47.c
@@ -62,7 +62,8 @@ static void IRAM_ATTR push_cfg_bit(bool bit) {
 
 static epd_config_register_t config_reg;
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
+    (void)init_config;
     /* Power Control Output/Off */
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_DATA], PIN_FUNC_GPIO);
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_CLK], PIN_FUNC_GPIO);

--- a/src/board/epd_board_v2_v3.c
+++ b/src/board/epd_board_v2_v3.c
@@ -61,7 +61,8 @@ static void IRAM_ATTR push_cfg_bit(bool bit) {
 
 static epd_config_register_t config_reg;
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
+    (void)init_config;
     /* Power Control Output/Off */
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_DATA], PIN_FUNC_GPIO);
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_CLK], PIN_FUNC_GPIO);

--- a/src/board/epd_board_v4.c
+++ b/src/board/epd_board_v4.c
@@ -64,7 +64,8 @@ static void IRAM_ATTR push_cfg_bit(bool bit) {
 
 static epd_config_register_t config_reg;
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
+    (void)init_config;
     /* Power Control Output/Off */
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_DATA], PIN_FUNC_GPIO);
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_CLK], PIN_FUNC_GPIO);

--- a/src/board/epd_board_v5.c
+++ b/src/board/epd_board_v5.c
@@ -65,7 +65,8 @@ static void IRAM_ATTR push_cfg_bit(bool bit) {
     gpio_set_level(CFG_CLK, 1);
 }
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
+    (void)init_config;
     /* Power Control Output/Off */
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_DATA], PIN_FUNC_GPIO);
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[CFG_CLK], PIN_FUNC_GPIO);

--- a/src/board/epd_board_v6.c
+++ b/src/board/epd_board_v6.c
@@ -92,10 +92,11 @@ static void IRAM_ATTR interrupt_handler(void* arg) {
 
 static epd_config_register_t config_reg;
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, init_config, true, true)
+    );
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;

--- a/src/board/epd_board_v6.c
+++ b/src/board/epd_board_v6.c
@@ -4,10 +4,16 @@
 #include <esp_log.h>
 #include <sdkconfig.h>
 #include <stdint.h>
+#include <stdio.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
 #include "../output_i2s/i2s_data_bus.h"
 #include "../output_i2s/render_i2s.h"
 #include "../output_i2s/rmt_pulse.h"
 #include "pca9555.h"
+#include "epd_board_i2c.h"
 #include "tps65185.h"
 
 // Make this compile on the S3 to avoid long ifdefs
@@ -21,7 +27,6 @@
 #define CFG_SCL GPIO_NUM_33
 #define CFG_SDA GPIO_NUM_32
 #define CFG_INTR GPIO_NUM_35
-#define EPDIY_I2C_PORT I2C_NUM_0
 #define CFG_PIN_OE (PCA_PIN_PC10 >> 8)
 #define CFG_PIN_MODE (PCA_PIN_PC11 >> 8)
 #define CFG_PIN_STV (PCA_PIN_PC12 >> 8)
@@ -49,12 +54,19 @@
 #define CKH GPIO_NUM_15
 
 typedef struct {
-    i2c_port_t port;
+    epd_board_i2c_context_t i2c;
     bool pwrup;
     bool vcom_ctrl;
     bool wakeup;
     bool others[8];
 } epd_config_register_t;
+
+static const epd_board_i2c_bus_config_t board_i2c_config = {
+    .port = I2C_NUM_0,
+    .sda_io_num = CFG_SDA,
+    .scl_io_num = CFG_SCL,
+    .bus_speed_hz = 400000,
+};
 
 static i2s_bus_config i2s_config = {
     .clock = CKH,
@@ -83,19 +95,7 @@ static epd_config_register_t config_reg;
 static void epd_board_init(uint32_t epd_row_width) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    i2c_config_t conf;
-    conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = CFG_SDA;
-    conf.scl_io_num = CFG_SCL;
-    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.master.clk_speed = 400000;
-    conf.clk_flags = I2C_SCLK_SRC_FLAG_FOR_NOMAL;
-    ESP_ERROR_CHECK(i2c_param_config(EPDIY_I2C_PORT, &conf));
-
-    ESP_ERROR_CHECK(i2c_driver_install(EPDIY_I2C_PORT, I2C_MODE_MASTER, 0, 0, 0));
-
-    config_reg.port = EPDIY_I2C_PORT;
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;
@@ -111,7 +111,7 @@ static void epd_board_init(uint32_t epd_row_width) {
     ESP_ERROR_CHECK(gpio_isr_handler_add(CFG_INTR, interrupt_handler, (void*)CFG_INTR));
 
     // set all epdiy lines to output except TPS interrupt + PWR good
-    ESP_ERROR_CHECK(pca9555_set_config(config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
+    ESP_ERROR_CHECK(pca9555_set_config(config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
 
     // use latch pin as GPIO
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[V4_LATCH_ENABLE], PIN_FUNC_GPIO);
@@ -130,25 +130,25 @@ static void epd_board_deinit() {
     // rtc_gpio_isolate(CFG_INTR);
 
     ESP_ERROR_CHECK(pca9555_set_config(
-        config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
+        config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
     ));
 
     int tries = 0;
-    while (!((pca9555_read_input(config_reg.port, 1) & 0xC0) == 0x80)) {
+    while (!((pca9555_read_input(config_reg.i2c.pca, 1) & 0xC0) == 0x80)) {
         if (tries >= 500) {
             ESP_LOGE("epdiy", "failed to shut down TPS65185!");
             break;
         }
         tries++;
         vTaskDelay(1);
-        printf("%X\n", pca9555_read_input(config_reg.port, 1));
+        printf("%X\n", pca9555_read_input(config_reg.i2c.pca, 1));
     }
     // Not sure why we need this delay, but the TPS65185 seems to generate an interrupt after some
     // time that needs to be cleared.
     vTaskDelay(500);
-    pca9555_read_input(config_reg.port, 0);
-    pca9555_read_input(config_reg.port, 1);
-    i2c_driver_delete(EPDIY_I2C_PORT);
+    pca9555_read_input(config_reg.i2c.pca, 0);
+    pca9555_read_input(config_reg.i2c.pca, 1);
+    epd_board_i2c_deinit(&config_reg.i2c);
     gpio_isr_handler_remove(CFG_INTR);
     gpio_uninstall_isr_service();
     gpio_reset_pin(CFG_INTR);
@@ -177,7 +177,7 @@ static void epd_board_set_ctrl(epd_ctrl_state_t* state, const epd_ctrl_state_t* 
         if (config_reg.wakeup)
             value |= CFG_PIN_WAKEUP;
 
-        ESP_ERROR_CHECK(pca9555_set_value(config_reg.port, value, 1));
+        ESP_ERROR_CHECK(pca9555_set_value(config_reg.i2c.pca, value, 1));
     }
 
     if (state->ep_latch_enable) {
@@ -213,13 +213,13 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     vTaskDelay(1);
 
     int tries = 0;
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! INT status: 0x%X 0x%X",
-                tps_read_register(config_reg.port, TPS_REG_INT1),
-                tps_read_register(config_reg.port, TPS_REG_INT2)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_INT1),
+                tps_read_register(config_reg.i2c.tps, TPS_REG_INT2)
             );
             return;
         }
@@ -227,9 +227,9 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
         vTaskDelay(1);
     }
 
-    ESP_ERROR_CHECK(tps_write_register(config_reg.port, TPS_REG_ENABLE, 0x3F));
+    ESP_ERROR_CHECK(tps_write_register(config_reg.i2c.tps, TPS_REG_ENABLE, 0x3F));
 
-    tps_set_vcom(config_reg.port, vcom);
+    tps_set_vcom(config_reg.i2c.tps, vcom);
 
     state->ep_sth = true;
     mask = (const epd_ctrl_state_t){
@@ -237,12 +237,12 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     };
     epd_board_set_ctrl(state, &mask);
 
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }
@@ -273,7 +273,7 @@ static void epd_board_measure_vcom(epd_ctrl_state_t* state) {
     };
     epd_board_set_ctrl(state, &mask);
 
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
     }
     ESP_LOGI("epdiy", "Power rails enabled");
 
@@ -284,12 +284,12 @@ static void epd_board_measure_vcom(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }
@@ -318,7 +318,7 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
 }
 
 static float epd_board_ambient_temperature() {
-    return tps_read_thermistor(EPDIY_I2C_PORT);
+    return tps_read_thermistor(config_reg.i2c.tps);
 }
 
 static esp_err_t gpio_set_direction_v6(int pin, bool make_input) {
@@ -326,14 +326,14 @@ static esp_err_t gpio_set_direction_v6(int pin, bool make_input) {
     uint8_t mask = ~(1 << pin);
     direction = (direction & mask) | (make_input << pin);
 
-    return pca9555_set_config(EPDIY_I2C_PORT, direction, 0);
+    return pca9555_set_config(config_reg.i2c.pca, direction, 0);
 }
 
 /**
  * Get the input level of the broken-out GPIO extender port.
  */
 static bool gpio_get_level_v6(int pin) {
-    return (pca9555_read_input(EPDIY_I2C_PORT, 0) >> pin) & 1;
+    return (pca9555_read_input(config_reg.i2c.pca, 0) >> pin) & 1;
 }
 
 /**
@@ -344,7 +344,7 @@ static esp_err_t gpio_set_value_v6(int pin, bool value) {
     uint8_t mask = ~(1 << pin);
     state = (state & mask) | (value << pin);
 
-    return pca9555_set_value(EPDIY_I2C_PORT, state, 0);
+    return pca9555_set_value(config_reg.i2c.pca, state, 0);
 }
 
 static void set_vcom(int value) {

--- a/src/board/epd_board_v7.c
+++ b/src/board/epd_board_v7.c
@@ -120,10 +120,11 @@ static lcd_bus_config_t lcd_config = {
     .data[15] = D15,
 };
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, init_config, true, true)
+    );
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;

--- a/src/board/epd_board_v7.c
+++ b/src/board/epd_board_v7.c
@@ -5,12 +5,17 @@
 #include "../output_common/render_method.h"
 #include "../output_lcd/lcd_driver.h"
 #include "esp_log.h"
+#include "epd_board_i2c.h"
 #include "pca9555.h"
 #include "tps65185.h"
 
 #include <driver/gpio.h>
-#include <driver/i2c.h>
 #include <sdkconfig.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <stdio.h>
 
 // Make this compile von the ESP32 without ifdefing the whole file
 #ifndef CONFIG_IDF_TARGET_ESP32S3
@@ -28,7 +33,6 @@
 #define CFG_SCL GPIO_NUM_40
 #define CFG_SDA GPIO_NUM_39
 #define CFG_INTR GPIO_NUM_38
-#define EPDIY_I2C_PORT I2C_NUM_0
 
 #define CFG_PIN_OE (PCA_PIN_PC10 >> 8)
 #define CFG_PIN_MODE (PCA_PIN_PC11 >> 8)
@@ -67,12 +71,19 @@
 #define CKH GPIO_NUM_4
 
 typedef struct {
-    i2c_port_t port;
+    epd_board_i2c_context_t i2c;
     bool pwrup;
     bool vcom_ctrl;
     bool wakeup;
     bool others[8];
 } epd_config_register_t;
+
+static const epd_board_i2c_bus_config_t board_i2c_config = {
+    .port = I2C_NUM_0,
+    .sda_io_num = CFG_SDA,
+    .scl_io_num = CFG_SCL,
+    .bus_speed_hz = 100000,
+};
 
 /** The VCOM voltage to use. */
 static int vcom = 1600;
@@ -112,19 +123,7 @@ static lcd_bus_config_t lcd_config = {
 static void epd_board_init(uint32_t epd_row_width) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    i2c_config_t conf;
-    conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = CFG_SDA;
-    conf.scl_io_num = CFG_SCL;
-    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.master.clk_speed = 100000;
-    conf.clk_flags = 0;
-    ESP_ERROR_CHECK(i2c_param_config(EPDIY_I2C_PORT, &conf));
-
-    ESP_ERROR_CHECK(i2c_driver_install(EPDIY_I2C_PORT, I2C_MODE_MASTER, 0, 0, 0));
-
-    config_reg.port = EPDIY_I2C_PORT;
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;
@@ -140,7 +139,7 @@ static void epd_board_init(uint32_t epd_row_width) {
     ESP_ERROR_CHECK(gpio_isr_handler_add(CFG_INTR, interrupt_handler, (void*)CFG_INTR));
 
     // set all epdiy lines to output except TPS interrupt + PWR good
-    ESP_ERROR_CHECK(pca9555_set_config(config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
+    ESP_ERROR_CHECK(pca9555_set_config(config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
 
     const EpdDisplay_t* display = epd_get_display();
 
@@ -159,11 +158,11 @@ static void epd_board_deinit() {
     epd_lcd_deinit();
 
     ESP_ERROR_CHECK(pca9555_set_config(
-        config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
+        config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
     ));
 
     int tries = 0;
-    while (!((pca9555_read_input(config_reg.port, 1) & 0xC0) == 0x80)) {
+    while (!((pca9555_read_input(config_reg.i2c.pca, 1) & 0xC0) == 0x80)) {
         if (tries >= 50) {
             ESP_LOGE("epdiy", "failed to shut down TPS65185!");
             break;
@@ -175,9 +174,9 @@ static void epd_board_deinit() {
     // Not sure why we need this delay, but the TPS65185 seems to generate an interrupt after some
     // time that needs to be cleared.
     vTaskDelay(50);
-    pca9555_read_input(config_reg.port, 0);
-    pca9555_read_input(config_reg.port, 1);
-    i2c_driver_delete(EPDIY_I2C_PORT);
+    pca9555_read_input(config_reg.i2c.pca, 0);
+    pca9555_read_input(config_reg.i2c.pca, 1);
+    epd_board_i2c_deinit(&config_reg.i2c);
 
     gpio_uninstall_isr_service();
 }
@@ -197,7 +196,7 @@ static void epd_board_set_ctrl(epd_ctrl_state_t* state, const epd_ctrl_state_t* 
         if (config_reg.wakeup)
             value |= CFG_PIN_WAKEUP;
 
-        ESP_ERROR_CHECK(pca9555_set_value(config_reg.port, value, 1));
+        ESP_ERROR_CHECK(pca9555_set_value(config_reg.i2c.pca, value, 1));
     }
 }
 
@@ -228,12 +227,12 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     // give the IC time to powerup and set lines
     vTaskDelay(1);
 
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
     }
 
-    ESP_ERROR_CHECK(tps_write_register(config_reg.port, TPS_REG_ENABLE, 0x3F));
+    ESP_ERROR_CHECK(tps_write_register(config_reg.i2c.tps, TPS_REG_ENABLE, 0x3F));
 
-    tps_set_vcom(config_reg.port, vcom);
+    tps_set_vcom(config_reg.i2c.tps, vcom);
 
     state->ep_sth = true;
     mask = (const epd_ctrl_state_t){
@@ -242,12 +241,12 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }
@@ -278,7 +277,7 @@ static void epd_board_measure_vcom(epd_ctrl_state_t* state) {
     };
     epd_board_set_ctrl(state, &mask);
 
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
     }
     ESP_LOGI("epdiy", "Power rails enabled");
 
@@ -289,12 +288,12 @@ static void epd_board_measure_vcom(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }

--- a/src/board/epd_board_v7_103.c
+++ b/src/board/epd_board_v7_103.c
@@ -120,10 +120,11 @@ static lcd_bus_config_t lcd_config = {
     .data[15] = D15,
 };
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, init_config, true, true)
+    );
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;

--- a/src/board/epd_board_v7_103.c
+++ b/src/board/epd_board_v7_103.c
@@ -5,12 +5,17 @@
 #include "../output_common/render_method.h"
 #include "../output_lcd/lcd_driver.h"
 #include "esp_log.h"
+#include "epd_board_i2c.h"
 #include "pca9555.h"
 #include "tps65185.h"
 
 #include <driver/gpio.h>
-#include <driver/i2c.h>
 #include <sdkconfig.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <stdio.h>
 
 // Make this compile von the ESP32 without ifdefing the whole file
 #ifndef CONFIG_IDF_TARGET_ESP32S3
@@ -28,7 +33,6 @@
 #define CFG_SCL GPIO_NUM_40
 #define CFG_SDA GPIO_NUM_39
 #define CFG_INTR GPIO_NUM_2  // NUM_2 is >1.1    NUM_38 is 1.0
-#define EPDIY_I2C_PORT I2C_NUM_0
 
 #define CFG_PIN_OE (PCA_PIN_PC10 >> 8)
 #define CFG_PIN_MODE (PCA_PIN_PC11 >> 8)
@@ -67,12 +71,19 @@
 #define CKH GPIO_NUM_4
 
 typedef struct {
-    i2c_port_t port;
+    epd_board_i2c_context_t i2c;
     bool pwrup;
     bool vcom_ctrl;
     bool wakeup;
     bool others[8];
 } epd_config_register_t;
+
+static const epd_board_i2c_bus_config_t board_i2c_config = {
+    .port = I2C_NUM_0,
+    .sda_io_num = CFG_SDA,
+    .scl_io_num = CFG_SCL,
+    .bus_speed_hz = 100000,
+};
 
 /** The VCOM voltage to use. */
 static int vcom = 1600;
@@ -112,19 +123,7 @@ static lcd_bus_config_t lcd_config = {
 static void epd_board_init(uint32_t epd_row_width) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    i2c_config_t conf;
-    conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = CFG_SDA;
-    conf.scl_io_num = CFG_SCL;
-    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.master.clk_speed = 100000;
-    conf.clk_flags = 0;
-    i2c_param_config(EPDIY_I2C_PORT, &conf);
-
-    i2c_driver_install(EPDIY_I2C_PORT, I2C_MODE_MASTER, 0, 0, 0);
-
-    config_reg.port = EPDIY_I2C_PORT;
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;
@@ -140,7 +139,7 @@ static void epd_board_init(uint32_t epd_row_width) {
     ESP_ERROR_CHECK(gpio_isr_handler_add(CFG_INTR, interrupt_handler, (void*)CFG_INTR));
 
     // set all epdiy lines to output except TPS interrupt + PWR good
-    ESP_ERROR_CHECK(pca9555_set_config(config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
+    ESP_ERROR_CHECK(pca9555_set_config(config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
 
     const EpdDisplay_t* display = epd_get_display();
 
@@ -159,11 +158,11 @@ static void epd_board_deinit() {
     epd_lcd_deinit();
 
     ESP_ERROR_CHECK(pca9555_set_config(
-        config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
+        config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
     ));
 
     int tries = 0;
-    while (!((pca9555_read_input(config_reg.port, 1) & 0xC0) == 0x80)) {
+    while (!((pca9555_read_input(config_reg.i2c.pca, 1) & 0xC0) == 0x80)) {
         if (tries >= 50) {
             ESP_LOGE("epdiy", "failed to shut down TPS65185!");
             break;
@@ -175,9 +174,9 @@ static void epd_board_deinit() {
     // Not sure why we need this delay, but the TPS65185 seems to generate an interrupt after some
     // time that needs to be cleared.
     vTaskDelay(50);
-    pca9555_read_input(config_reg.port, 0);
-    pca9555_read_input(config_reg.port, 1);
-    i2c_driver_delete(EPDIY_I2C_PORT);
+    pca9555_read_input(config_reg.i2c.pca, 0);
+    pca9555_read_input(config_reg.i2c.pca, 1);
+    epd_board_i2c_deinit(&config_reg.i2c);
 
     gpio_uninstall_isr_service();
 }
@@ -197,7 +196,7 @@ static void epd_board_set_ctrl(epd_ctrl_state_t* state, const epd_ctrl_state_t* 
         if (config_reg.wakeup)
             value |= CFG_PIN_WAKEUP;
 
-        ESP_ERROR_CHECK(pca9555_set_value(config_reg.port, value, 1));
+        ESP_ERROR_CHECK(pca9555_set_value(config_reg.i2c.pca, value, 1));
     }
 }
 
@@ -229,7 +228,7 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     // give the IC time to powerup and set lines
     vTaskDelay(1);
     int i = 0;
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
         vTaskDelay(1);
         i++;
         if (i == 10) {
@@ -238,9 +237,9 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
         }
     }
 
-    ESP_ERROR_CHECK(tps_write_register(config_reg.port, TPS_REG_ENABLE, 0x3F));
+    ESP_ERROR_CHECK(tps_write_register(config_reg.i2c.tps, TPS_REG_ENABLE, 0x3F));
 
-    tps_set_vcom(config_reg.port, vcom);
+    tps_set_vcom(config_reg.i2c.tps, vcom);
 
     state->ep_sth = true;
     mask = (const epd_ctrl_state_t){
@@ -249,12 +248,12 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }
@@ -285,7 +284,7 @@ static void epd_board_measure_vcom(epd_ctrl_state_t* state) {
     };
     epd_board_set_ctrl(state, &mask);
 
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
     }
     ESP_LOGI("epdiy", "Power rails enabled");
 
@@ -296,12 +295,12 @@ static void epd_board_measure_vcom(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }

--- a/src/board/epd_board_v7_raw.c
+++ b/src/board/epd_board_v7_raw.c
@@ -11,11 +11,14 @@
 #include "../output_common/render_method.h"
 #include "../output_lcd/lcd_driver.h"
 #include "esp_log.h"
+#include "epd_board_i2c.h"
 #include "tps65185.h"
 
 #include <driver/gpio.h>
-#include <driver/i2c.h>
 #include <sdkconfig.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 // Make this compile on the ESP32 without ifdefing the whole file
 #ifndef CONFIG_IDF_TARGET_ESP32S3
@@ -32,7 +35,6 @@
 
 #define CFG_SCL GPIO_NUM_40
 #define CFG_SDA GPIO_NUM_39
-#define EPDIY_I2C_PORT I2C_NUM_0
 
 #define CFG_PIN_OE GPIO_NUM_9
 #define CFG_PIN_MODE GPIO_NUM_10
@@ -62,12 +64,19 @@
 #define CKH GPIO_NUM_4
 
 typedef struct {
-    i2c_port_t port;
+    epd_board_i2c_context_t i2c;
     bool pwrup;
     bool vcom_ctrl;
     bool wakeup;
     bool others[8];
 } epd_config_register_t;
+
+static const epd_board_i2c_bus_config_t board_i2c_config = {
+    .port = I2C_NUM_0,
+    .sda_io_num = CFG_SDA,
+    .scl_io_num = CFG_SCL,
+    .bus_speed_hz = 100000,
+};
 
 /** The VCOM voltage to use. */
 static int vcom = 1900;
@@ -97,19 +106,7 @@ static lcd_bus_config_t lcd_config = { .clock = CKH,
 static void epd_board_init(uint32_t epd_row_width) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    i2c_config_t conf;
-    conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = CFG_SDA;
-    conf.scl_io_num = CFG_SCL;
-    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.master.clk_speed = 100000;
-    conf.clk_flags = 0;
-    ESP_ERROR_CHECK(i2c_param_config(EPDIY_I2C_PORT, &conf));
-
-    ESP_ERROR_CHECK(i2c_driver_install(EPDIY_I2C_PORT, I2C_MODE_MASTER, 0, 0, 0));
-
-    config_reg.port = EPDIY_I2C_PORT;
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, false));
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;
@@ -158,7 +155,7 @@ static void epd_board_deinit() {
     // Not sure why we need this delay, but the TPS65185 seems to generate an interrupt after some
     // time that needs to be cleared.
     vTaskDelay(50);
-    i2c_driver_delete(EPDIY_I2C_PORT);
+    epd_board_i2c_deinit(&config_reg.i2c);
 
     gpio_uninstall_isr_service();
 }
@@ -229,15 +226,15 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     }
     ESP_LOGI("v7_RAW", "PWRGOOD OK");
 
-    tps_set_vcom(config_reg.port, vcom);
+    tps_set_vcom(config_reg.i2c.tps, vcom);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }
@@ -264,7 +261,7 @@ static void epd_board_poweroff(epd_ctrl_state_t* state) {
 }
 
 static float epd_board_ambient_temperature() {
-    return tps_read_thermistor(EPDIY_I2C_PORT);
+    return tps_read_thermistor(config_reg.i2c.tps);
 }
 
 static void set_vcom(int value) {

--- a/src/board/epd_board_v7_raw.c
+++ b/src/board/epd_board_v7_raw.c
@@ -103,10 +103,11 @@ static lcd_bus_config_t lcd_config = { .clock = CKH,
                                        .data[6] = D6,
                                        .data[7] = D7 };
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, false));
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, init_config, true, false)
+    );
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;

--- a/src/board/lilygo_board_s3.c
+++ b/src/board/lilygo_board_s3.c
@@ -5,12 +5,15 @@
 #include "../output_common/render_method.h"
 #include "../output_lcd/lcd_driver.h"
 #include "esp_log.h"
+#include "epd_board_i2c.h"
 #include "pca9555.h"
 #include "tps65185.h"
 
 #include <driver/gpio.h>
-#include <driver/i2c.h>
 #include <sdkconfig.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 // Make this compile von the ESP32 without ifdefing the whole file
 #ifndef CONFIG_IDF_TARGET_ESP32S3
@@ -28,7 +31,6 @@
 #define CFG_SCL GPIO_NUM_40
 #define CFG_SDA GPIO_NUM_39
 #define CFG_INTR GPIO_NUM_38
-#define EPDIY_I2C_PORT I2C_NUM_0
 
 #define CFG_PIN_OE (PCA_PIN_PC10 >> 8)
 #define CFG_PIN_MODE (PCA_PIN_PC11 >> 8)
@@ -58,12 +60,19 @@
 #define CKH GPIO_NUM_4
 
 typedef struct {
-    i2c_port_t port;
+    epd_board_i2c_context_t i2c;
     bool pwrup;
     bool vcom_ctrl;
     bool wakeup;
     bool others[8];
 } epd_config_register_t;
+
+static const epd_board_i2c_bus_config_t board_i2c_config = {
+    .port = I2C_NUM_0,
+    .sda_io_num = CFG_SDA,
+    .scl_io_num = CFG_SCL,
+    .bus_speed_hz = 100000,
+};
 
 /** The VCOM voltage to use. */
 static int vcom = 1600;
@@ -95,19 +104,7 @@ static lcd_bus_config_t lcd_config = {
 static void epd_board_init(uint32_t epd_row_width) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    i2c_config_t conf;
-    conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = CFG_SDA;
-    conf.scl_io_num = CFG_SCL;
-    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.master.clk_speed = 100000;
-    conf.clk_flags = 0;
-    ESP_ERROR_CHECK(i2c_param_config(EPDIY_I2C_PORT, &conf));
-
-    ESP_ERROR_CHECK(i2c_driver_install(EPDIY_I2C_PORT, I2C_MODE_MASTER, 0, 0, 0));
-
-    config_reg.port = EPDIY_I2C_PORT;
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;
@@ -123,7 +120,7 @@ static void epd_board_init(uint32_t epd_row_width) {
     ESP_ERROR_CHECK(gpio_isr_handler_add(CFG_INTR, interrupt_handler, (void*)CFG_INTR));
 
     // set all epdiy lines to output except TPS interrupt + PWR good
-    ESP_ERROR_CHECK(pca9555_set_config(config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
+    ESP_ERROR_CHECK(pca9555_set_config(config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT, 1));
 
     const EpdDisplay_t* display = epd_get_display();
 
@@ -142,11 +139,11 @@ static void epd_board_deinit() {
     epd_lcd_deinit();
 
     ESP_ERROR_CHECK(pca9555_set_config(
-        config_reg.port, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
+        config_reg.i2c.pca, CFG_PIN_PWRGOOD | CFG_PIN_INT | CFG_PIN_VCOM_CTRL | CFG_PIN_PWRUP, 1
     ));
 
     int tries = 0;
-    while (!((pca9555_read_input(config_reg.port, 1) & 0xC0) == 0x80)) {
+    while (!((pca9555_read_input(config_reg.i2c.pca, 1) & 0xC0) == 0x80)) {
         if (tries >= 50) {
             ESP_LOGE("epdiy", "failed to shut down TPS65185!");
             break;
@@ -158,9 +155,9 @@ static void epd_board_deinit() {
     // Not sure why we need this delay, but the TPS65185 seems to generate an interrupt after some
     // time that needs to be cleared.
     vTaskDelay(50);
-    pca9555_read_input(config_reg.port, 0);
-    pca9555_read_input(config_reg.port, 1);
-    i2c_driver_delete(EPDIY_I2C_PORT);
+    pca9555_read_input(config_reg.i2c.pca, 0);
+    pca9555_read_input(config_reg.i2c.pca, 1);
+    epd_board_i2c_deinit(&config_reg.i2c);
 
     gpio_uninstall_isr_service();
 }
@@ -180,7 +177,7 @@ static void epd_board_set_ctrl(epd_ctrl_state_t* state, const epd_ctrl_state_t* 
         if (config_reg.wakeup)
             value |= CFG_PIN_WAKEUP;
 
-        ESP_ERROR_CHECK(pca9555_set_value(config_reg.port, value, 1));
+        ESP_ERROR_CHECK(pca9555_set_value(config_reg.i2c.pca, value, 1));
     }
 }
 
@@ -203,12 +200,12 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     // give the IC time to powerup and set lines
     vTaskDelay(1);
 
-    while (!(pca9555_read_input(config_reg.port, 1) & CFG_PIN_PWRGOOD)) {
+    while (!(pca9555_read_input(config_reg.i2c.pca, 1) & CFG_PIN_PWRGOOD)) {
     }
 
-    ESP_ERROR_CHECK(tps_write_register(config_reg.port, TPS_REG_ENABLE, 0x3F));
+    ESP_ERROR_CHECK(tps_write_register(config_reg.i2c.tps, TPS_REG_ENABLE, 0x3F));
 
-    tps_set_vcom(config_reg.port, vcom);
+    tps_set_vcom(config_reg.i2c.tps, vcom);
 
     state->ep_sth = true;
     mask = (const epd_ctrl_state_t){
@@ -217,12 +214,12 @@ static void epd_board_poweron(epd_ctrl_state_t* state) {
     epd_board_set_ctrl(state, &mask);
 
     int tries = 0;
-    while (!((tps_read_register(config_reg.port, TPS_REG_PG) & 0xFA) == 0xFA)) {
+    while (!((tps_read_register(config_reg.i2c.tps, TPS_REG_PG) & 0xFA) == 0xFA)) {
         if (tries >= 500) {
             ESP_LOGE(
                 "epdiy",
                 "Power enable failed! PG status: %X",
-                tps_read_register(config_reg.port, TPS_REG_PG)
+                tps_read_register(config_reg.i2c.tps, TPS_REG_PG)
             );
             return;
         }

--- a/src/board/lilygo_board_s3.c
+++ b/src/board/lilygo_board_s3.c
@@ -101,10 +101,11 @@ static lcd_bus_config_t lcd_config = {
     .data[7] = D7,
 };
 
-static void epd_board_init(uint32_t epd_row_width) {
+static void epd_board_init(uint32_t epd_row_width, const EpdInitConfig* init_config) {
     gpio_hold_dis(CKH);  // free CKH after wakeup
 
-    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, true, true));
+    ESP_ERROR_CHECK(epd_board_i2c_init(&config_reg.i2c, &board_i2c_config, init_config, true, true)
+    );
     config_reg.pwrup = false;
     config_reg.vcom_ctrl = false;
     config_reg.wakeup = false;

--- a/src/board/pca9555.c
+++ b/src/board/pca9555.c
@@ -1,10 +1,10 @@
 
 
 #include "pca9555.h"
-#include <driver/i2c.h>
 #include <esp_err.h>
 #include <esp_log.h>
 #include <stdint.h>
+#include <string.h>
 
 #define REG_INPUT_PORT0 0
 #define REG_INPUT_PORT1 1
@@ -18,86 +18,52 @@
 #define REG_CONFIG_PORT0 6
 #define REG_CONFIG_PORT1 7
 
-static esp_err_t i2c_master_read_slave(i2c_port_t i2c_num, uint8_t* data_rd, size_t size, int reg) {
+static esp_err_t i2c_master_read_slave(
+    i2c_master_dev_handle_t dev, uint8_t* data_rd, size_t size, int reg
+) {
     if (size == 0) {
         return ESP_OK;
     }
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    if (cmd == NULL) {
-        ESP_LOGE("epdiy", "insufficient memory for I2C transaction");
-    }
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (EPDIY_PCA9555_ADDR << 1) | I2C_MASTER_WRITE, true);
-    i2c_master_write_byte(cmd, reg, true);
-    i2c_master_stop(cmd);
-
-    esp_err_t ret = i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_PERIOD_MS);
-    if (ret != ESP_OK) {
-        return ret;
-    }
-    i2c_cmd_link_delete(cmd);
-
-    cmd = i2c_cmd_link_create();
-    if (cmd == NULL) {
-        ESP_LOGE("epdiy", "insufficient memory for I2C transaction");
-    }
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (EPDIY_PCA9555_ADDR << 1) | I2C_MASTER_READ, true);
-    if (size > 1) {
-        i2c_master_read(cmd, data_rd, size - 1, I2C_MASTER_ACK);
-    }
-    i2c_master_read_byte(cmd, data_rd + size - 1, I2C_MASTER_NACK);
-    i2c_master_stop(cmd);
-
-    ret = i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_PERIOD_MS);
-    if (ret != ESP_OK) {
-        return ret;
-    }
-    i2c_cmd_link_delete(cmd);
-
-    return ESP_OK;
+    uint8_t reg_addr = reg;
+    return i2c_master_transmit_receive(dev, &reg_addr, sizeof(reg_addr), data_rd, size, -1);
 }
 
 static esp_err_t i2c_master_write_slave(
-    i2c_port_t i2c_num, uint8_t ctrl, uint8_t* data_wr, size_t size
+    i2c_master_dev_handle_t dev, uint8_t ctrl, uint8_t* data_wr, size_t size
 ) {
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    if (cmd == NULL) {
-        ESP_LOGE("epdiy", "insufficient memory for I2C transaction");
+    uint8_t write_buffer[3] = { ctrl, 0, 0 };
+    if (size > sizeof(write_buffer) - 1) {
+        ESP_LOGE("epdiy", "I2C write too large for PCA9555 helper");
+        return ESP_ERR_INVALID_SIZE;
     }
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (EPDIY_PCA9555_ADDR << 1) | I2C_MASTER_WRITE, true);
-    i2c_master_write_byte(cmd, ctrl, true);
-
-    i2c_master_write(cmd, data_wr, size, true);
-    i2c_master_stop(cmd);
-    esp_err_t ret = i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_PERIOD_MS);
-    i2c_cmd_link_delete(cmd);
-    return ret;
+    memcpy(write_buffer + 1, data_wr, size);
+    return i2c_master_transmit(dev, write_buffer, size + 1, -1);
 }
 
-static esp_err_t pca9555_write_single(i2c_port_t port, int reg, uint8_t value) {
+static esp_err_t pca9555_write_single(i2c_master_dev_handle_t dev, int reg, uint8_t value) {
     uint8_t w_data[1] = { value };
-    return i2c_master_write_slave(port, reg, w_data, sizeof(w_data));
+    return i2c_master_write_slave(dev, reg, w_data, sizeof(w_data));
 }
 
-esp_err_t pca9555_set_config(i2c_port_t port, uint8_t config_value, int high_port) {
-    return pca9555_write_single(port, REG_CONFIG_PORT0 + high_port, config_value);
+esp_err_t pca9555_set_config(i2c_master_dev_handle_t dev, uint8_t config_value, int high_port) {
+    return pca9555_write_single(dev, REG_CONFIG_PORT0 + high_port, config_value);
 }
 
-esp_err_t pca9555_set_inversion(i2c_port_t port, uint8_t config_value, int high_port) {
-    return pca9555_write_single(port, REG_INVERT_PORT0 + high_port, config_value);
+esp_err_t pca9555_set_inversion(
+    i2c_master_dev_handle_t dev, uint8_t config_value, int high_port
+) {
+    return pca9555_write_single(dev, REG_INVERT_PORT0 + high_port, config_value);
 }
 
-esp_err_t pca9555_set_value(i2c_port_t port, uint8_t config_value, int high_port) {
-    return pca9555_write_single(port, REG_OUTPUT_PORT0 + high_port, config_value);
+esp_err_t pca9555_set_value(i2c_master_dev_handle_t dev, uint8_t config_value, int high_port) {
+    return pca9555_write_single(dev, REG_OUTPUT_PORT0 + high_port, config_value);
 }
 
-uint8_t pca9555_read_input(i2c_port_t i2c_port, int high_port) {
+uint8_t pca9555_read_input(i2c_master_dev_handle_t dev, int high_port) {
     esp_err_t err;
     uint8_t r_data[1];
 
-    err = i2c_master_read_slave(i2c_port, r_data, 1, REG_INPUT_PORT0 + high_port);
+    err = i2c_master_read_slave(dev, r_data, 1, REG_INPUT_PORT0 + high_port);
     if (err != ESP_OK) {
         ESP_LOGE("PCA9555", "%s failed", __func__);
         return 0;

--- a/src/board/pca9555.c
+++ b/src/board/pca9555.c
@@ -49,9 +49,7 @@ esp_err_t pca9555_set_config(i2c_master_dev_handle_t dev, uint8_t config_value, 
     return pca9555_write_single(dev, REG_CONFIG_PORT0 + high_port, config_value);
 }
 
-esp_err_t pca9555_set_inversion(
-    i2c_master_dev_handle_t dev, uint8_t config_value, int high_port
-) {
+esp_err_t pca9555_set_inversion(i2c_master_dev_handle_t dev, uint8_t config_value, int high_port) {
     return pca9555_write_single(dev, REG_INVERT_PORT0 + high_port, config_value);
 }
 

--- a/src/board/pca9555.h
+++ b/src/board/pca9555.h
@@ -1,7 +1,7 @@
 #ifndef PCA9555_H
 #define PCA9555_H
 
-#include <driver/i2c.h>
+#include <driver/i2c_master.h>
 #include <esp_err.h>
 
 #define PCA_PIN_P00 0x0001
@@ -25,11 +25,11 @@
 #define PCA_PIN_ALL 0xFFFF
 #define PCA_PIN_NULL 0x0000
 
-static const int EPDIY_PCA9555_ADDR = 0x20;
+#define EPDIY_PCA9555_ADDR 0x20
 
-uint8_t pca9555_read_input(i2c_port_t port, int high_port);
-esp_err_t pca9555_set_value(i2c_port_t port, uint8_t config_value, int high_port);
-esp_err_t pca9555_set_inversion(i2c_port_t port, uint8_t config_value, int high_port);
-esp_err_t pca9555_set_config(i2c_port_t port, uint8_t config_value, int high_port);
+uint8_t pca9555_read_input(i2c_master_dev_handle_t dev, int high_port);
+esp_err_t pca9555_set_value(i2c_master_dev_handle_t dev, uint8_t config_value, int high_port);
+esp_err_t pca9555_set_inversion(i2c_master_dev_handle_t dev, uint8_t config_value, int high_port);
+esp_err_t pca9555_set_config(i2c_master_dev_handle_t dev, uint8_t config_value, int high_port);
 
 #endif  // PCA9555_H

--- a/src/board/tps65185.c
+++ b/src/board/tps65185.c
@@ -1,84 +1,63 @@
 
 #include "tps65185.h"
-#include "pca9555.h"
+#include "epd_board_i2c.h"
 #include "epd_board.h"
 #include "esp_err.h"
 #include "esp_log.h"
 
-#include <driver/i2c.h>
+#include <assert.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
-static const int EPDIY_TPS_ADDR = 0x68;
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
-static uint8_t i2c_master_read_slave(i2c_port_t i2c_num, int reg) {
+static uint8_t i2c_master_read_slave(i2c_master_dev_handle_t dev, int reg) {
     uint8_t r_data[1];
 
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (EPDIY_TPS_ADDR << 1) | I2C_MASTER_WRITE, true);
-    i2c_master_write_byte(cmd, reg, true);
-    i2c_master_stop(cmd);
-
-    ESP_ERROR_CHECK(i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_PERIOD_MS));
-    i2c_cmd_link_delete(cmd);
-
-    cmd = i2c_cmd_link_create();
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (EPDIY_TPS_ADDR << 1) | I2C_MASTER_READ, true);
-    /*
-        if (size > 1) {
-        i2c_master_read(cmd, data_rd, size - 1, I2C_MASTER_ACK);
-    }
-    */
-    i2c_master_read_byte(cmd, r_data, I2C_MASTER_NACK);
-    i2c_master_stop(cmd);
-
-    ESP_ERROR_CHECK(i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_PERIOD_MS));
-    i2c_cmd_link_delete(cmd);
+    uint8_t reg_addr = reg;
+    ESP_ERROR_CHECK(i2c_master_transmit_receive(dev, &reg_addr, sizeof(reg_addr), r_data, 1, -1));
 
     return r_data[0];
 }
 
 static esp_err_t i2c_master_write_slave(
-    i2c_port_t i2c_num, uint8_t ctrl, uint8_t* data_wr, size_t size
+    i2c_master_dev_handle_t dev, uint8_t ctrl, uint8_t* data_wr, size_t size
 ) {
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (EPDIY_TPS_ADDR << 1) | I2C_MASTER_WRITE, true);
-    i2c_master_write_byte(cmd, ctrl, true);
-
-    i2c_master_write(cmd, data_wr, size, true);
-    i2c_master_stop(cmd);
-    esp_err_t ret = i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_PERIOD_MS);
-    i2c_cmd_link_delete(cmd);
-    return ret;
+    uint8_t write_buffer[3] = { ctrl, 0, 0 };
+    if (size > sizeof(write_buffer) - 1) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    memcpy(write_buffer + 1, data_wr, size);
+    return i2c_master_transmit(dev, write_buffer, size + 1, -1);
 }
 
-esp_err_t tps_write_register(i2c_port_t port, int reg, uint8_t value) {
+esp_err_t tps_write_register(i2c_master_dev_handle_t dev, int reg, uint8_t value) {
     uint8_t w_data[1];
     esp_err_t err;
 
     w_data[0] = value;
 
-    err = i2c_master_write_slave(port, reg, w_data, 1);
+    err = i2c_master_write_slave(dev, reg, w_data, 1);
     return err;
 }
 
-uint8_t tps_read_register(i2c_port_t i2c_num, int reg) {
-    return i2c_master_read_slave(i2c_num, reg);
+uint8_t tps_read_register(i2c_master_dev_handle_t dev, int reg) {
+    return i2c_master_read_slave(dev, reg);
 }
 
-void tps_set_vcom(i2c_port_t i2c_num, unsigned vcom_mV) {
+void tps_set_vcom(i2c_master_dev_handle_t dev, unsigned vcom_mV) {
     unsigned val = vcom_mV / 10;
-    ESP_ERROR_CHECK(tps_write_register(i2c_num, 4, (val & 0x100) >> 8));
-    ESP_ERROR_CHECK(tps_write_register(i2c_num, 3, val & 0xFF));
+    ESP_ERROR_CHECK(tps_write_register(dev, 4, (val & 0x100) >> 8));
+    ESP_ERROR_CHECK(tps_write_register(dev, 3, val & 0xFF));
 }
 
-int8_t tps_read_thermistor(i2c_port_t i2c_num) {
-    tps_write_register(i2c_num, TPS_REG_TMST1, 0x80);
+int8_t tps_read_thermistor(i2c_master_dev_handle_t dev) {
+    tps_write_register(dev, TPS_REG_TMST1, 0x80);
     int tries = 0;
     while (true) {
-        uint8_t val = tps_read_register(i2c_num, TPS_REG_TMST1);
+        uint8_t val = tps_read_register(dev, TPS_REG_TMST1);
         // temperature conversion done
         if (val & 0x20) {
             break;
@@ -90,7 +69,13 @@ int8_t tps_read_thermistor(i2c_port_t i2c_num) {
             break;
         }
     }
-    return (int8_t)tps_read_register(i2c_num, TPS_REG_TMST_VALUE);
+    return (int8_t)tps_read_register(dev, TPS_REG_TMST_VALUE);
+}
+
+static i2c_master_dev_handle_t current_tps() {
+    i2c_master_dev_handle_t dev = epd_board_i2c_current_tps();
+    assert(dev != NULL);
+    return dev;
 }
 
 void tps_vcom_kickback() {
@@ -100,27 +85,30 @@ void tps_vcom_kickback() {
     // set the HiZ bit in the VCOM2 register (BIT 5) 0x20
     // this puts the VCOM pin in a high-impedance state.
     // bit 3 & 4 Number of acquisitions that is averaged to a single kick-back V. measurement
-    tps_write_register(I2C_NUM_0, 4, 0x38);
+    i2c_master_dev_handle_t dev = current_tps();
+    tps_write_register(dev, 4, 0x38);
     vTaskDelay(1);
 
-    uint8_t int1reg = tps_read_register(I2C_NUM_0, TPS_REG_INT1);
-    uint8_t vcomreg = tps_read_register(I2C_NUM_0, TPS_REG_VCOM2);
+    uint8_t int1reg = tps_read_register(dev, TPS_REG_INT1);
+    uint8_t vcomreg = tps_read_register(dev, TPS_REG_VCOM2);
 }
 
 void tps_vcom_kickback_start() {
-    uint8_t int1reg = tps_read_register(I2C_NUM_0, TPS_REG_INT1);
+    i2c_master_dev_handle_t dev = current_tps();
+    uint8_t int1reg = tps_read_register(dev, TPS_REG_INT1);
     // set the ACQ bit in the VCOM2 register to 1 (BIT 7)
-    tps_write_register(I2C_NUM_0, TPS_REG_VCOM2, 0xA0);
+    tps_write_register(dev, TPS_REG_VCOM2, 0xA0);
 }
 
 unsigned tps_vcom_kickback_rdy() {
-    uint8_t int1reg = tps_read_register(I2C_NUM_0, TPS_REG_INT1);
+    i2c_master_dev_handle_t dev = current_tps();
+    uint8_t int1reg = tps_read_register(dev, TPS_REG_INT1);
 
     if (int1reg == 0x02) {
-        uint8_t lsb = tps_read_register(I2C_NUM_0, 3);
-        uint8_t msb = tps_read_register(I2C_NUM_0, 4);
+        uint8_t lsb = tps_read_register(dev, 3);
+        uint8_t msb = tps_read_register(dev, 4);
         int u16Value = (lsb | (msb << 8)) & 0x1ff;
-        ESP_LOGI("vcom", "raw value:%d temperature:%d C", u16Value, tps_read_thermistor(I2C_NUM_0));
+        ESP_LOGI("vcom", "raw value:%d temperature:%d C", u16Value, tps_read_thermistor(dev));
         return u16Value * 10;
     } else {
         return 0;
@@ -128,6 +116,7 @@ unsigned tps_vcom_kickback_rdy() {
 }
 
 void tps_set_upseq_carta1300() {
-    tps_write_register(I2C_NUM_0, TPS_REG_UPSEQ0, 0xE1);
-    tps_write_register(I2C_NUM_0, TPS_REG_UPSEQ1, 0xAA);
+    i2c_master_dev_handle_t dev = current_tps();
+    tps_write_register(dev, TPS_REG_UPSEQ0, 0xE1);
+    tps_write_register(dev, TPS_REG_UPSEQ1, 0xAA);
 }

--- a/src/board/tps65185.h
+++ b/src/board/tps65185.h
@@ -1,7 +1,7 @@
 #ifndef TPS65185_H
 #define TPS65185_H
 
-#include <driver/i2c.h>
+#include <driver/i2c_master.h>
 
 #define TPS_REG_TMST_VALUE 0x00
 #define TPS_REG_ENABLE 0x01
@@ -21,13 +21,13 @@
 #define TPS_REG_PG 0x0F
 #define TPS_REG_REVID 0x10
 
-esp_err_t tps_write_register(i2c_port_t port, int reg, uint8_t value);
-uint8_t tps_read_register(i2c_port_t i2c_num, int reg);
+esp_err_t tps_write_register(i2c_master_dev_handle_t dev, int reg, uint8_t value);
+uint8_t tps_read_register(i2c_master_dev_handle_t dev, int reg);
 
 /**
  * Sets the VCOM voltage in positive milivolts: 1600 -> -1.6V
  */
-void tps_set_vcom(i2c_port_t i2c_num, unsigned vcom_mV);
+void tps_set_vcom(i2c_master_dev_handle_t dev, unsigned vcom_mV);
 
 /**
  * @brief Please read datasheet section 8.3.7.1 Kick-Back Voltage Measurement
@@ -55,6 +55,6 @@ void tps_set_upseq_carta1300();
 /**
  * Read the temperature via the on-board thermistor.
  */
-int8_t tps_read_thermistor(i2c_port_t i2c_num);
+int8_t tps_read_thermistor(i2c_master_dev_handle_t dev);
 
 #endif  //  TPS65185_H

--- a/src/epd_board.h
+++ b/src/epd_board.h
@@ -11,6 +11,8 @@
 #include <esp_err.h>
 #include <xtensa/core-macros.h>
 
+#include "epd_init_config.h"
+
 /**
  * State of display control pins.
  */
@@ -29,7 +31,7 @@ typedef struct {
     /**
      * Initialize the board.
      */
-    void (*init)(uint32_t epd_row_width);
+    void (*init)(uint32_t epd_row_width, const EpdInitConfig* init_config);
     /**
      * Clean up resources and peripherals used by the board.
      */

--- a/src/epd_init_config.h
+++ b/src/epd_init_config.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <driver/i2c_master.h>
+
+typedef struct EpdI2cConfig {
+    i2c_master_bus_handle_t bus_handle;
+} EpdI2cConfig;
+
+typedef struct EpdInitConfig {
+    const EpdI2cConfig* i2c;
+} EpdInitConfig;

--- a/src/epdiy.c
+++ b/src/epdiy.c
@@ -16,7 +16,6 @@ typedef struct {
 } Coord_xy;
 
 static const EpdDisplay_t* display = NULL;
-static const EpdInitConfig* init_config = NULL;
 
 // Display rotation. Can be updated using epd_set_rotation(enum EpdRotation)
 static enum EpdRotation display_rotation = EPD_ROT_LANDSCAPE;
@@ -498,9 +497,8 @@ void epd_init_with_config(
     const EpdInitConfig* config
 ) {
     display = disp;
-    init_config = config;
     epd_set_board(board);
-    epd_renderer_init(options);
+    epd_renderer_init(options, config);
 }
 
 void epd_deinit() {
@@ -536,10 +534,6 @@ void epd_set_vcom(uint16_t vcom) {
 const EpdDisplay_t* epd_get_display() {
     assert(display != NULL);
     return display;
-}
-
-const EpdInitConfig* epd_get_init_config() {
-    return init_config;
 }
 
 int epd_width() {

--- a/src/epdiy.c
+++ b/src/epdiy.c
@@ -16,6 +16,7 @@ typedef struct {
 } Coord_xy;
 
 static const EpdDisplay_t* display = NULL;
+static const EpdInitConfig* init_config = NULL;
 
 // Display rotation. Can be updated using epd_set_rotation(enum EpdRotation)
 static enum EpdRotation display_rotation = EPD_ROT_LANDSCAPE;
@@ -487,7 +488,17 @@ void epd_poweroff() {
 void epd_init(
     const EpdBoardDefinition* board, const EpdDisplay_t* disp, enum EpdInitOptions options
 ) {
+    epd_init_with_config(board, disp, options, NULL);
+}
+
+void epd_init_with_config(
+    const EpdBoardDefinition* board,
+    const EpdDisplay_t* disp,
+    enum EpdInitOptions options,
+    const EpdInitConfig* config
+) {
     display = disp;
+    init_config = config;
     epd_set_board(board);
     epd_renderer_init(options);
 }
@@ -525,6 +536,10 @@ void epd_set_vcom(uint16_t vcom) {
 const EpdDisplay_t* epd_get_display() {
     assert(display != NULL);
     return display;
+}
+
+const EpdInitConfig* epd_get_init_config() {
+    return init_config;
 }
 
 int epd_width() {

--- a/src/epdiy.h
+++ b/src/epdiy.h
@@ -12,6 +12,8 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <driver/i2c_master.h>
+
 #include "epd_internals.h"
 
 /// An area on the display.
@@ -44,6 +46,14 @@ enum EpdInitOptions {
     /// Best performance, but larger memory footprint.
     EPD_FEED_QUEUE_32 = 8,
 };
+
+typedef struct {
+    i2c_master_bus_handle_t bus_handle;
+} EpdI2cConfig;
+
+typedef struct {
+    const EpdI2cConfig* i2c;
+} EpdInitConfig;
 
 /// The image drawing mode.
 enum EpdDrawMode {
@@ -204,6 +214,14 @@ typedef struct {
 /** Initialize the ePaper display */
 void epd_init(
     const EpdBoardDefinition* board, const EpdDisplay_t* display, enum EpdInitOptions options
+);
+
+/** Initialize the ePaper display with optional bus configuration overrides. */
+void epd_init_with_config(
+    const EpdBoardDefinition* board,
+    const EpdDisplay_t* display,
+    enum EpdInitOptions options,
+    const EpdInitConfig* config
 );
 
 /**

--- a/src/epdiy.h
+++ b/src/epdiy.h
@@ -12,8 +12,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <driver/i2c_master.h>
-
+#include "epd_init_config.h"
 #include "epd_internals.h"
 
 /// An area on the display.
@@ -46,14 +45,6 @@ enum EpdInitOptions {
     /// Best performance, but larger memory footprint.
     EPD_FEED_QUEUE_32 = 8,
 };
-
-typedef struct {
-    i2c_master_bus_handle_t bus_handle;
-} EpdI2cConfig;
-
-typedef struct {
-    const EpdI2cConfig* i2c;
-} EpdInitConfig;
 
 /// The image drawing mode.
 enum EpdDrawMode {

--- a/src/render.c
+++ b/src/render.c
@@ -236,12 +236,12 @@ void epd_clear_area_cycles(EpdRect area, int cycles, int cycle_time) {
     }
 }
 
-void epd_renderer_init(enum EpdInitOptions options) {
+void epd_renderer_init(enum EpdInitOptions options, const EpdInitConfig* config) {
     // Either the board should be set in menuconfig or the epd_set_board() must
     // be called before epd_init()
     assert((epd_current_board() != NULL));
 
-    epd_current_board()->init(epd_width());
+    epd_current_board()->init(epd_width(), config);
     epd_control_reg_init();
 
     render_context.display_width = epd_width();

--- a/src/render.h
+++ b/src/render.h
@@ -4,7 +4,7 @@
 /**
  * Initialize the EPD renderer and its render context.
  */
-void epd_renderer_init(enum EpdInitOptions options);
+void epd_renderer_init(enum EpdInitOptions options, const EpdInitConfig* config);
 
 /**
  * Deinitialize the EPD renderer and free up its resources.

--- a/test/test_initialization.c
+++ b/test/test_initialization.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <driver/i2c_master.h>
 #include <unity.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -10,9 +11,26 @@
 // choose the default demo board depending on the architecture
 #ifdef CONFIG_IDF_TARGET_ESP32
 #define TEST_BOARD epd_board_v6
+#define TEST_I2C_SCL GPIO_NUM_33
+#define TEST_I2C_SDA GPIO_NUM_32
+#define TEST_I2C_SPEED_HZ 400000
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
 #define TEST_BOARD epd_board_v7
+#define TEST_I2C_SCL GPIO_NUM_40
+#define TEST_I2C_SDA GPIO_NUM_39
+#define TEST_I2C_SPEED_HZ 100000
 #endif
+
+static i2c_master_bus_config_t make_test_i2c_bus_config(void) {
+    return (i2c_master_bus_config_t){
+        .i2c_port = I2C_NUM_0,
+        .sda_io_num = TEST_I2C_SDA,
+        .scl_io_num = TEST_I2C_SCL,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+}
 
 TEST_CASE("initialization and deinitialization works", "[epdiy,e2e]") {
     epd_init(&TEST_BOARD, &ED097TC2, EPD_OPTIONS_DEFAULT);
@@ -43,4 +61,43 @@ TEST_CASE("re-initialization works", "[epdiy,e2e]") {
     epd_deinit();
     int after_init = esp_get_free_internal_heap_size();
     TEST_ASSERT_EQUAL(after_init, before_init);
+}
+
+TEST_CASE("initialization with external i2c bus keeps bus alive", "[epdiy][i2c][e2e]") {
+    i2c_master_bus_handle_t bus_handle = NULL;
+    i2c_master_bus_config_t bus_config = make_test_i2c_bus_config();
+    TEST_ASSERT_EQUAL(ESP_OK, i2c_new_master_bus(&bus_config, &bus_handle));
+
+    EpdI2cConfig i2c_config = {
+        .bus_handle = bus_handle,
+    };
+    EpdInitConfig init_config = {
+        .i2c = &i2c_config,
+    };
+
+    epd_init_with_config(&TEST_BOARD, &ED097TC2, EPD_OPTIONS_DEFAULT, &init_config);
+
+    epd_poweron();
+    vTaskDelay(2);
+    epd_poweroff();
+
+    epd_deinit();
+
+    TEST_ASSERT_EQUAL(ESP_OK, i2c_del_master_bus(bus_handle));
+}
+
+TEST_CASE("initialization with internal i2c bus releases bus on deinit", "[epdiy][i2c][e2e]") {
+    i2c_master_bus_handle_t bus_handle = NULL;
+
+    epd_init(&TEST_BOARD, &ED097TC2, EPD_OPTIONS_DEFAULT);
+
+    epd_poweron();
+    vTaskDelay(2);
+    epd_poweroff();
+
+    epd_deinit();
+
+    i2c_master_bus_config_t bus_config = make_test_i2c_bus_config();
+    TEST_ASSERT_EQUAL(ESP_OK, i2c_new_master_bus(&bus_config, &bus_handle));
+    TEST_ASSERT_EQUAL(ESP_OK, i2c_del_master_bus(bus_handle));
 }


### PR DESCRIPTION
# Summary
- Replace the deprecated legacy I2C usage in epdiy board bring-up with the ESP-IDF master bus/device API so the project keeps working on current IDF releases.
- Add an explicit epd_init_with_config(...) path so callers can reuse an existing I2C bus, while keeping epd_init(...) as the compatibility entry point for existing code.
- Centralize board I2C setup/teardown and add initialization tests that verify both ownership modes: epdiy releases buses it creates and preserves buses supplied by the caller.

# Functional Changes
- Board power / GPIO-expander / PMIC access now uses the new IDF I2C bus and device handles instead of the deprecated legacy driver APIs.
- epdiy can now initialize against an externally created I2C bus via EpdInitConfig.
- Board init config is now passed explicitly through the init path instead of being read from hidden global state.
- The test suite now covers I2C bus ownership behavior during init/deinit.