### PR TITLE
ci: update checkout action version, simplify checkout, prevent duplicate runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,11 @@ on:
 jobs:
   format-check:
     runs-on: ubuntu-latest
-    container:
-      image: "espressif/idf:v5.4"
     steps:
       - uses: actions/checkout@v6
+      - name: Install clang-format
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq clang-format-18
       - run: |
-          . $IDF_PATH/export.sh
-          idf_tools.py install esp-clang
-          . $IDF_PATH/export.sh
           which clang-format
           make format-check
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: "espressif/idf:v5.4"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |
           . $IDF_PATH/export.sh
           idf_tools.py install esp-clang
@@ -47,7 +47,7 @@ jobs:
     continue-on-error: ${{ matrix.version == 'latest' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - uses: 'espressif/esp-idf-ci-action@main'
@@ -67,15 +67,15 @@ jobs:
           - v5.3.2
         example:
           - weather
-        arduino-esp32: 
-          - 3.1.3 
+        arduino-esp32:
+          - 3.1.3
 
     steps:
       - name: Install latest git
         run: |
           apt update -qq && apt install -y -qq git
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Arduino ESP
         run: |
           cd examples/${{ matrix.example }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: 'espressif/esp-idf-ci-action@main'
+      - uses: 'espressif/esp-idf-ci-action@v1'
         with:
           esp_idf_version: ${{ matrix.version }}
           target: ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,16 +71,16 @@ jobs:
           - 3.1.3
 
     steps:
-      - name: Install latest git
-        run: |
-          apt update -qq && apt install -y -qq git
       - name: Checkout repo
         uses: actions/checkout@v6
-      - name: Install Arduino ESP
-        run: |
-          cd examples/${{ matrix.example }}
-          mkdir components && cd components
-          git clone --depth 1 --recursive --branch ${{ matrix.arduino-esp32 }} https://github.com/espressif/arduino-esp32.git arduino
+      - name: Checkout Arduino ESP
+        uses: actions/checkout@v6
+        with:
+          repository: espressif/arduino-esp32
+          ref: ${{ matrix.arduino-esp32 }}
+          path: examples/${{ matrix.example }}/components/arduino
+          submodules: recursive
+          fetch-depth: 1
       - name: esp-idf build
         run: |
           . $IDF_PATH/export.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: ESP-IDF
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   format-check:


### PR DESCRIPTION
What started simply as a bump to the checkout action version has evolved into 
- bump actions/checkout to v6 - [per GitHub node.js 24 migration](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- arduino-esp32 checkout step didn't need to install git, just use the checkout action again - it is faster and does the same job!
- trigger scope updated so updates to PRs don't result in double run of CI workflow
- pin espressif/esp-idf-ci-action to v1 - [per the recommendation in the action docs](https://github.com/espressif/esp-idf-ci-action/tree/v1)
- install clang-format directly rather than via esp-idf. for a straightforward format/lint check, we don't need the esp-format version as we aren't interested in code generation or target support... only C/C++ syntax. 

I'm pretty confident of the first four changes, but I understand if the last one isn't wanted, and can remove that if desired. However, one thing to keep in mind is the difference of approx 20s for the format-check action to run, vs 90 - 120s depending on the runner workloads (not to mention the ~3.59 GB image download every run). 