### PR TITLE
Fix incorrect calloc size for line_queue bufs pointer array

### DIFF
--- a/src/output_common/line_queue.c
+++ b/src/output_common/line_queue.c
@@ -22,7 +22,7 @@ LineQueue_t lq_init(int queue_len, int element_size) {
 
     int elem_buf_size = ceil_div(element_size, 16) * 16;
 
-    queue.bufs = calloc(queue.size, elem_buf_size);
+    queue.bufs = calloc(queue.size, sizeof(uint8_t*));
     assert(queue.bufs != NULL);
 
     for (int i = 0; i < queue.size; i++) {


### PR DESCRIPTION
## Problem

In `src/output_common/line_queue.c`, `lq_init()` allocates the `bufs`
pointer array like this:

```c
int elem_buf_size = ceil_div(element_size, 16) * 16;

queue.bufs = calloc(queue.size, elem_buf_size);
assert(queue.bufs != NULL);

for (int i = 0; i < queue.size; i++) {
    queue.bufs[i] = heap_caps_aligned_alloc(16, elem_buf_size, MALLOC_CAP_INTERNAL);
    assert(queue.bufs[i] != NULL);
}
```

`bufs` is declared as `uint8_t** bufs;` in `line_queue.h` — an array of
`queue.size` pointers. But the `calloc()` call sizes each element as
`elem_buf_size` (the per-line payload buffer size) instead of
`sizeof(uint8_t*)`. Only the first `queue.size * sizeof(uint8_t*)`
bytes of the calloc'd block are ever written to (as `bufs[0..size-1]`);
the remainder is allocated and zeroed but never used, since the actual
per-line payload buffers are allocated separately right below via
`heap_caps_aligned_alloc(..., MALLOC_CAP_INTERNAL)`.

This wastes internal SRAM on every `epd_renderer_init()` call. For
example, with the default `queue_len` of 32
(`EPD_FEED_QUEUE_32`) and a line size of 400 bytes (e.g. the ED133UT2
LCD-interface path, `display_width / 4`), the calloc requests
32 * 400 = 12,800 bytes when only 32 * 4 = 128 bytes (on a 32-bit
target) is actually needed — about 12.4KB wasted per queue, and since
`lq_init()` is called once per render thread
(`NUM_RENDER_THREADS == 2`), roughly 25KB of `MALLOC_CAP_INTERNAL`
memory wasted in total.

## Fix

Size the `calloc()` call for the pointer array it actually is:

```c
queue.bufs = calloc(queue.size, sizeof(uint8_t*));
```

This is a one-line change with no behavior change — the payload
buffers are unaffected, since they were already correctly allocated
separately in the loop below. Verified with a standalone reproduction
matching the real struct layout and `lq_init()` logic: identical
read/write-through behavior before and after the fix, only the
allocation footprint changes.